### PR TITLE
feat(web): improve loading state with skeleton UI

### DIFF
--- a/packages/web/src/app/[locale]/sessions/[id]/page.tsx
+++ b/packages/web/src/app/[locale]/sessions/[id]/page.tsx
@@ -13,6 +13,7 @@ import { Timeline } from '@/components/timeline/Timeline';
 import { TerminalOutput } from '@/components/terminal/TerminalOutput';
 import { ApprovalList } from '@/components/approval/ApprovalList';
 import { CodeReviewPanel } from '@/components/review/CodeReviewPanel';
+import { Skeleton, SkeletonText } from '@/components/Skeleton';
 import { useWebSocket } from '@/hooks/useWebSocket';
 
 export default function SessionDetailPage() {
@@ -115,7 +116,127 @@ export default function SessionDetailPage() {
   };
 
   if (loading) {
-    return <div style={{ padding: '24px' }}>Loading...</div>;
+    return (
+      <main style={{ minHeight: '100vh', padding: '24px' }}>
+        {/* Header Skeleton */}
+        <div style={{ marginBottom: '24px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <Skeleton width="120px" height="14px" style={{ marginBottom: '8px' }} />
+              <Skeleton width="200px" height="28px" style={{ marginBottom: '8px' }} />
+              <Skeleton width="100px" height="14px" />
+            </div>
+            <Skeleton width="120px" height="36px" borderRadius="6px" />
+          </div>
+        </div>
+
+        {/* Grid Skeleton */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, 1fr)',
+            gap: '24px',
+          }}
+        >
+          {/* Terminal Output Skeleton */}
+          <section>
+            <Skeleton width="120px" height="16px" style={{ marginBottom: '12px' }} />
+            <div
+              style={{
+                background: 'var(--terminal-bg)',
+                borderRadius: '8px',
+                padding: '16px',
+                height: '300px',
+              }}
+            >
+              <SkeletonText lines={8} />
+            </div>
+          </section>
+
+          {/* Timeline Skeleton */}
+          <section>
+            <Skeleton width="80px" height="16px" style={{ marginBottom: '12px' }} />
+            <div
+              style={{
+                background: 'var(--bg-secondary)',
+                borderRadius: '8px',
+                padding: '16px',
+                maxHeight: '400px',
+              }}
+            >
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: 'flex',
+                    gap: '12px',
+                    marginBottom: '16px',
+                    alignItems: 'flex-start',
+                  }}
+                >
+                  <Skeleton width="8px" height="8px" borderRadius="50%" style={{ marginTop: '4px' }} />
+                  <div style={{ flex: 1 }}>
+                    <Skeleton width="60%" height="14px" style={{ marginBottom: '4px' }} />
+                    <Skeleton width="80px" height="12px" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Tool Approvals Skeleton */}
+          <section>
+            <Skeleton width="120px" height="16px" style={{ marginBottom: '12px' }} />
+            <div
+              style={{
+                background: 'var(--bg-secondary)',
+                borderRadius: '8px',
+                padding: '16px',
+              }}
+            >
+              {Array.from({ length: 2 }).map((_, i) => (
+                <div
+                  key={i}
+                  style={{
+                    padding: '12px',
+                    border: '1px solid var(--border)',
+                    borderRadius: '6px',
+                    marginBottom: i < 1 ? '12px' : 0,
+                  }}
+                >
+                  <Skeleton width="40%" height="14px" style={{ marginBottom: '8px' }} />
+                  <Skeleton width="80%" height="12px" style={{ marginBottom: '12px' }} />
+                  <div style={{ display: 'flex', gap: '8px' }}>
+                    <Skeleton width="80px" height="32px" borderRadius="6px" />
+                    <Skeleton width="80px" height="32px" borderRadius="6px" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Code Review Skeleton */}
+          <section>
+            <Skeleton width="100px" height="16px" style={{ marginBottom: '12px' }} />
+            <div
+              style={{
+                background: 'var(--bg-secondary)',
+                borderRadius: '8px',
+                padding: '16px',
+              }}
+            >
+              <Skeleton width="50%" height="18px" style={{ marginBottom: '16px' }} />
+              <SkeletonText lines={4} />
+              <div style={{ display: 'flex', gap: '8px', marginTop: '16px' }}>
+                <Skeleton width="100px" height="32px" borderRadius="6px" />
+                <Skeleton width="100px" height="32px" borderRadius="6px" />
+                <Skeleton width="140px" height="32px" borderRadius="6px" />
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    );
   }
 
   if (error || !session) {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -152,6 +152,12 @@
   100% { background-position: 200% 0; }
 }
 
+/* Skeleton pulse for loading states */
+@keyframes skeleton-pulse {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
 /* Terminal cursor blink */
 @keyframes cursor-blink {
   0%, 50% { opacity: 1; }

--- a/packages/web/src/components/Skeleton.tsx
+++ b/packages/web/src/components/Skeleton.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { CSSProperties } from 'react';
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  borderRadius?: string | number;
+  style?: CSSProperties;
+}
+
+export function Skeleton({
+  width = '100%',
+  height = '16px',
+  borderRadius = '4px',
+  style,
+}: SkeletonProps) {
+  return (
+    <div
+      style={{
+        width,
+        height,
+        borderRadius,
+        background: 'linear-gradient(90deg, var(--bg-secondary) 25%, var(--bg-tertiary, #3a3a3a) 50%, var(--bg-secondary) 75%)',
+        backgroundSize: '200% 100%',
+        animation: 'skeleton-pulse 1.5s ease-in-out infinite',
+        ...style,
+      }}
+    />
+  );
+}
+
+export function SkeletonText({ lines = 3 }: { lines?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton
+          key={i}
+          width={i === lines - 1 ? '60%' : '100%'}
+          height="14px"
+        />
+      ))}
+    </div>
+  );
+}
+
+export function SkeletonCard({ height = '200px' }: { height?: string }) {
+  return (
+    <div
+      style={{
+        background: 'var(--bg-secondary)',
+        borderRadius: '8px',
+        padding: '16px',
+        height,
+      }}
+    >
+      <Skeleton width="40%" height="20px" style={{ marginBottom: '16px' }} />
+      <SkeletonText lines={4} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Skeleton UI 컴포넌트(`Skeleton`, `SkeletonText`, `SkeletonCard`) 추가
- 세션 상세 페이지 로딩 상태를 실제 레이아웃과 일치하는 skeleton으로 교체
- 레이아웃 shift 방지 및 UX 개선

## Changes
- `packages/web/src/components/Skeleton.tsx`: 새 컴포넌트
- `packages/web/src/app/globals.css`: skeleton-pulse 애니메이션 추가
- `packages/web/src/app/[locale]/sessions/[id]/page.tsx`: skeleton 로딩 상태 적용

## Test plan
- [ ] 세션 상세 페이지 접속 시 skeleton UI 표시 확인
- [ ] 로딩 완료 후 레이아웃 shift 없이 콘텐츠 표시 확인
- [ ] 빌드 성공 확인 (`pnpm build`)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)