### PR TITLE
test(core): add tests for AIReviewGenerator, ValidationGateRunner, Logger

### DIFF
--- a/packages/core/src/infra/ai/AIReviewGenerator.test.ts
+++ b/packages/core/src/infra/ai/AIReviewGenerator.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { generateAIReviewSummary, type GenerateReviewOptions } from './AIReviewGenerator.js';
+import * as childProcess from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+// Mock child_process.spawn
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+describe('AIReviewGenerator', () => {
+  let spawnMock: ReturnType<typeof vi.fn>;
+
+  const createMockProcess = (
+    stdout: string,
+    stderr: string,
+    exitCode: number,
+    options?: { shouldError?: boolean; errorMessage?: string }
+  ): ChildProcess => {
+    const proc = new EventEmitter() as ChildProcess & { stdout: EventEmitter; stderr: EventEmitter };
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+
+    // Schedule data and close events
+    setTimeout(() => {
+      if (options?.shouldError) {
+        proc.emit('error', new Error(options.errorMessage || 'Process error'));
+      } else {
+        proc.stdout.emit('data', Buffer.from(stdout));
+        proc.stderr.emit('data', Buffer.from(stderr));
+        proc.emit('close', exitCode);
+      }
+    }, 0);
+
+    return proc;
+  };
+
+  beforeEach(() => {
+    spawnMock = vi.mocked(childProcess.spawn);
+    spawnMock.mockReset();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  describe('generateAIReviewSummary', () => {
+    const baseOptions: GenerateReviewOptions = {
+      sessionId: 'test-session-123',
+      workingDir: '/test/project',
+      baseBranch: 'main',
+    };
+
+    it('should return null when there are no changes', async () => {
+      // First call: git diff --stat returns empty
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('', '', 0)
+      );
+      // Second call: git diff (detailed) - should not be reached if first is empty
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('', '', 0)
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result).toBeNull();
+    });
+
+    it('should generate review summary successfully', async () => {
+      const diffStat = ' src/test.ts | 10 +++++-----\n 1 file changed';
+      const detailedDiff = 'diff --git a/src/test.ts\n+added line\n-removed line';
+      const claudeResponse = JSON.stringify({
+        summary: 'Added new feature',
+        whatChanged: ['Added test file'],
+        whyChanged: 'To improve coverage',
+        potentialIssues: [],
+        suggestions: ['Add more tests'],
+        riskLevel: 'low',
+      });
+
+      // git diff --stat
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess(diffStat, '', 0)
+      );
+      // git diff (detailed)
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess(detailedDiff, '', 0)
+      );
+      // claude CLI
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess(claudeResponse, '', 0)
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result).not.toBeNull();
+      expect(result?.sessionId).toBe('test-session-123');
+      expect(result?.summary).toBe('Added new feature');
+      expect(result?.whatChanged).toContain('Added test file');
+      expect(result?.whyChanged).toBe('To improve coverage');
+      expect(result?.suggestions).toContain('Add more tests');
+      expect(result?.riskLevel).toBe('low');
+      expect(result?.generatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should use develop as default base branch', async () => {
+      const optionsWithoutBranch: GenerateReviewOptions = {
+        sessionId: 'test-session',
+        workingDir: '/test',
+      };
+
+      spawnMock.mockImplementation((cmd, args) => {
+        if (cmd === 'git' && args.includes('diff')) {
+          // Check that develop is used
+          expect(args).toContain('develop');
+        }
+        return createMockProcess('', '', 0);
+      });
+
+      await generateAIReviewSummary(optionsWithoutBranch);
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['develop']),
+        expect.any(Object)
+      );
+    });
+
+    it('should handle git command failure', async () => {
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('', 'fatal: not a git repository', 1)
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle claude CLI failure', async () => {
+      // git diff --stat
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('file.ts | 5 +++++', '', 0)
+      );
+      // git diff detailed
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('+line', '', 0)
+      );
+      // claude CLI fails
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('', 'API error', 1)
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle invalid JSON response from Claude', async () => {
+      // git diff --stat
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('file.ts | 5 +++++', '', 0)
+      );
+      // git diff detailed
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('+line', '', 0)
+      );
+      // claude returns invalid JSON
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('This is not JSON', '', 0)
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result).toBeNull();
+    });
+
+    it('should extract JSON from Claude response with extra text', async () => {
+      // git diff --stat
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('file.ts | 5 +++++', '', 0)
+      );
+      // git diff detailed
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('+line', '', 0)
+      );
+      // claude returns JSON with surrounding text
+      const responseWithExtra = `Here's my analysis:
+${JSON.stringify({
+  summary: 'Test summary',
+  whatChanged: ['change 1'],
+  whyChanged: 'reason',
+  potentialIssues: [],
+  suggestions: [],
+  riskLevel: 'low',
+})}
+Let me know if you need more details.`;
+
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess(responseWithExtra, '', 0)
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result).not.toBeNull();
+      expect(result?.summary).toBe('Test summary');
+    });
+
+    it('should handle missing fields in Claude response with defaults', async () => {
+      // git diff --stat
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('file.ts | 5 +++++', '', 0)
+      );
+      // git diff detailed
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('+line', '', 0)
+      );
+      // claude returns partial JSON
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('{}', '', 0)
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result).not.toBeNull();
+      expect(result?.summary).toBe('No summary available');
+      expect(result?.whatChanged).toEqual([]);
+      expect(result?.whyChanged).toBe('Unknown');
+      expect(result?.potentialIssues).toEqual([]);
+      expect(result?.suggestions).toEqual([]);
+      expect(result?.riskLevel).toBe('low');
+    });
+
+    it('should parse potential issues correctly', async () => {
+      // git diff --stat
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('file.ts | 5 +++++', '', 0)
+      );
+      // git diff detailed
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('+line', '', 0)
+      );
+      // claude returns response with issues
+      const responseWithIssues = JSON.stringify({
+        summary: 'Test',
+        whatChanged: [],
+        whyChanged: 'test',
+        potentialIssues: [
+          {
+            severity: 'warning',
+            title: 'Security issue',
+            description: 'Potential XSS vulnerability',
+            file: 'src/component.tsx',
+            line: 42,
+          },
+          {
+            severity: 'info',
+            title: 'Style suggestion',
+            description: 'Consider using const',
+          },
+        ],
+        suggestions: [],
+        riskLevel: 'medium',
+      });
+
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess(responseWithIssues, '', 0)
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result?.potentialIssues).toHaveLength(2);
+      expect(result?.potentialIssues[0]).toEqual({
+        severity: 'warning',
+        title: 'Security issue',
+        description: 'Potential XSS vulnerability',
+        file: 'src/component.tsx',
+        line: 42,
+      });
+      expect(result?.potentialIssues[1]?.file).toBeUndefined();
+    });
+
+    it('should handle process spawn error', async () => {
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('', '', 0, { shouldError: true, errorMessage: 'spawn failed' })
+      );
+
+      const result = await generateAIReviewSummary(baseOptions);
+
+      expect(result).toBeNull();
+    });
+
+    it('should truncate very long diffs in prompt', async () => {
+      const longDiff = 'A'.repeat(20000); // Longer than maxDiffLength (15000)
+
+      // git diff --stat
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess('file.ts | 5 +++++', '', 0)
+      );
+      // git diff detailed - very long
+      spawnMock.mockImplementationOnce(() =>
+        createMockProcess(longDiff, '', 0)
+      );
+      // claude CLI
+      spawnMock.mockImplementationOnce((cmd, args) => {
+        // Verify the prompt contains truncation marker
+        if (cmd === 'claude') {
+          const prompt = args[1]; // -p <prompt>
+          expect(prompt).toContain('... (truncated)');
+        }
+        return createMockProcess(JSON.stringify({
+          summary: 'test',
+          whatChanged: [],
+          whyChanged: 'test',
+          potentialIssues: [],
+          suggestions: [],
+          riskLevel: 'low',
+        }), '', 0);
+      });
+
+      await generateAIReviewSummary(baseOptions);
+
+      // The test passes if no errors and the mock verifications pass
+      expect(spawnMock).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/packages/core/src/infra/logger/Logger.test.ts
+++ b/packages/core/src/infra/logger/Logger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { createLogger, type Logger } from './Logger.js';
 
 describe('Logger', () => {

--- a/packages/core/src/infra/logger/Logger.test.ts
+++ b/packages/core/src/infra/logger/Logger.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createLogger, type Logger } from './Logger.js';
+
+describe('Logger', () => {
+  describe('createLogger', () => {
+    it('should create logger with correct namespace', () => {
+      const logger = createLogger('test-module');
+
+      expect(logger).toBeDefined();
+      expect(logger.info).toBeDefined();
+      expect(logger.error).toBeDefined();
+      expect(logger.debug).toBeDefined();
+    });
+
+    it('should create logger with info, error, debug methods', () => {
+      const logger = createLogger('mymodule');
+
+      expect(typeof logger.info).toBe('function');
+      expect(typeof logger.error).toBe('function');
+      expect(typeof logger.debug).toBe('function');
+    });
+
+    it('should use claudetree namespace prefix', () => {
+      const logger = createLogger('session');
+
+      // debug module sets namespace on the function
+      expect(logger.info.namespace).toBe('claudetree:session:info');
+      expect(logger.error.namespace).toBe('claudetree:session:error');
+      expect(logger.debug.namespace).toBe('claudetree:session:debug');
+    });
+
+    it('should create independent loggers for different modules', () => {
+      const logger1 = createLogger('module1');
+      const logger2 = createLogger('module2');
+
+      expect(logger1.info.namespace).not.toBe(logger2.info.namespace);
+      expect(logger1.info.namespace).toBe('claudetree:module1:info');
+      expect(logger2.info.namespace).toBe('claudetree:module2:info');
+    });
+  });
+
+  describe('Logger interface', () => {
+    let logger: Logger;
+
+    beforeEach(() => {
+      logger = createLogger('test');
+    });
+
+    it('should have info method that is callable', () => {
+      // Should not throw
+      expect(() => logger.info('test message')).not.toThrow();
+    });
+
+    it('should have error method that is callable', () => {
+      expect(() => logger.error('error message')).not.toThrow();
+    });
+
+    it('should have debug method that is callable', () => {
+      expect(() => logger.debug('debug message')).not.toThrow();
+    });
+
+    it('should support format strings', () => {
+      expect(() => logger.info('User %s logged in', 'john')).not.toThrow();
+      expect(() => logger.error('Error code: %d', 500)).not.toThrow();
+      expect(() => logger.debug('Object: %O', { key: 'value' })).not.toThrow();
+    });
+  });
+});

--- a/packages/core/src/infra/validation/ValidationGateRunner.test.ts
+++ b/packages/core/src/infra/validation/ValidationGateRunner.test.ts
@@ -7,7 +7,6 @@ import {
 } from './ValidationGateRunner.js';
 import type { ValidationGate } from '@claudetree/shared';
 import * as childProcess from 'node:child_process';
-import { promisify } from 'node:util';
 
 vi.mock('node:child_process', () => ({
   exec: vi.fn(),
@@ -110,12 +109,12 @@ describe('ValidationGateRunner', () => {
 
       const result = await runner.runGate(gate, options);
 
-      expect(result.output.length).toBeLessThan(longOutput.length);
+      expect(result.output?.length).toBeLessThan(longOutput.length);
       expect(result.output).toContain('... (truncated)');
     });
 
     it('should use default timeout when not specified', async () => {
-      execMock.mockImplementation((cmd, opts, callback) => {
+      execMock.mockImplementation((_cmd, opts, callback) => {
         // Check that timeout is set
         expect((opts as { timeout?: number }).timeout).toBe(5 * 60 * 1000);
         if (typeof callback === 'function') {

--- a/packages/core/src/infra/validation/ValidationGateRunner.test.ts
+++ b/packages/core/src/infra/validation/ValidationGateRunner.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ValidationGateRunner,
+  DEFAULT_GATES,
+  detectProjectGates,
+  type GateRunOptions,
+} from './ValidationGateRunner.js';
+import type { ValidationGate } from '@claudetree/shared';
+import * as childProcess from 'node:child_process';
+import { promisify } from 'node:util';
+
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('../logger/index.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe('ValidationGateRunner', () => {
+  let runner: ValidationGateRunner;
+  let execMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    runner = new ValidationGateRunner();
+    execMock = vi.mocked(childProcess.exec);
+    execMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('runGate', () => {
+    const gate: ValidationGate = {
+      name: 'test',
+      command: 'npm test',
+      required: true,
+    };
+
+    const options: GateRunOptions = {
+      cwd: '/test/project',
+      maxRetries: 3,
+      timeout: 10000,
+    };
+
+    it('should run gate successfully on first attempt', async () => {
+      execMock.mockImplementation((_cmd, _opts, callback) => {
+        if (typeof callback === 'function') {
+          callback(null, { stdout: 'All tests passed', stderr: '' });
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const result = await runner.runGate(gate, options);
+
+      expect(result.gateName).toBe('test');
+      expect(result.passed).toBe(true);
+      expect(result.attempts).toBe(1);
+      expect(result.output).toContain('All tests passed');
+      expect(result.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('should retry on failure and eventually pass', async () => {
+      let callCount = 0;
+      execMock.mockImplementation((_cmd, _opts, callback) => {
+        callCount++;
+        if (typeof callback === 'function') {
+          if (callCount < 2) {
+            callback(new Error('Test failed'), { stdout: '', stderr: 'Error' });
+          } else {
+            callback(null, { stdout: 'Tests passed', stderr: '' });
+          }
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const result = await runner.runGate(gate, options);
+
+      expect(result.passed).toBe(true);
+      expect(result.attempts).toBe(2);
+    });
+
+    it('should fail after max retries exceeded', async () => {
+      execMock.mockImplementation((_cmd, _opts, callback) => {
+        if (typeof callback === 'function') {
+          callback(new Error('Test failed'), { stdout: '', stderr: 'Error output' });
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const result = await runner.runGate(gate, options);
+
+      expect(result.passed).toBe(false);
+      expect(result.attempts).toBe(3);
+    });
+
+    it('should truncate long output', async () => {
+      const longOutput = 'A'.repeat(2000);
+      execMock.mockImplementation((_cmd, _opts, callback) => {
+        if (typeof callback === 'function') {
+          callback(null, { stdout: longOutput, stderr: '' });
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const result = await runner.runGate(gate, options);
+
+      expect(result.output.length).toBeLessThan(longOutput.length);
+      expect(result.output).toContain('... (truncated)');
+    });
+
+    it('should use default timeout when not specified', async () => {
+      execMock.mockImplementation((cmd, opts, callback) => {
+        // Check that timeout is set
+        expect((opts as { timeout?: number }).timeout).toBe(5 * 60 * 1000);
+        if (typeof callback === 'function') {
+          callback(null, { stdout: 'OK', stderr: '' });
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const optionsWithoutTimeout: GateRunOptions = {
+        cwd: '/test',
+        maxRetries: 1,
+      };
+
+      await runner.runGate(gate, optionsWithoutTimeout);
+    });
+  });
+
+  describe('runAll', () => {
+    const gates: ValidationGate[] = [
+      { name: 'install', command: 'npm ci', required: true },
+      { name: 'test', command: 'npm test', required: true },
+      { name: 'lint', command: 'npm run lint', required: false },
+    ];
+
+    const options: GateRunOptions = {
+      cwd: '/test',
+      maxRetries: 1,
+    };
+
+    it('should run all gates in sequence', async () => {
+      const executionOrder: string[] = [];
+      execMock.mockImplementation((cmd, _opts, callback) => {
+        executionOrder.push(cmd as string);
+        if (typeof callback === 'function') {
+          callback(null, { stdout: 'OK', stderr: '' });
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const result = await runner.runAll(gates, options);
+
+      expect(result.results).toHaveLength(3);
+      expect(result.allPassed).toBe(true);
+      expect(result.totalTime).toBeGreaterThanOrEqual(0);
+      expect(executionOrder).toEqual(['npm ci', 'npm test', 'npm run lint']);
+    });
+
+    it('should stop on required gate failure', async () => {
+      execMock.mockImplementation((cmd, _opts, callback) => {
+        if (typeof callback === 'function') {
+          if (cmd === 'npm test') {
+            callback(new Error('Failed'), { stdout: '', stderr: 'Error' });
+          } else {
+            callback(null, { stdout: 'OK', stderr: '' });
+          }
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const result = await runner.runAll(gates, options);
+
+      expect(result.allPassed).toBe(false);
+      expect(result.results).toHaveLength(2); // Stops after failed required gate
+      expect(result.results[1]?.passed).toBe(false);
+    });
+
+    it('should continue on optional gate failure', async () => {
+      const gatesWithOptional: ValidationGate[] = [
+        { name: 'test', command: 'npm test', required: true },
+        { name: 'lint', command: 'npm run lint', required: false },
+        { name: 'build', command: 'npm run build', required: true },
+      ];
+
+      execMock.mockImplementation((cmd, _opts, callback) => {
+        if (typeof callback === 'function') {
+          if (cmd === 'npm run lint') {
+            callback(new Error('Lint failed'), { stdout: '', stderr: '' });
+          } else {
+            callback(null, { stdout: 'OK', stderr: '' });
+          }
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const result = await runner.runAll(gatesWithOptional, options);
+
+      expect(result.allPassed).toBe(true);
+      expect(result.results).toHaveLength(3);
+      expect(result.results[1]?.passed).toBe(false);
+      expect(result.results[2]?.passed).toBe(true);
+    });
+  });
+
+  describe('runWithAutoRetry', () => {
+    const gates: ValidationGate[] = [
+      { name: 'test', command: 'npm test', required: true },
+    ];
+
+    it('should retry full validation on failure', async () => {
+      let overallCalls = 0;
+      execMock.mockImplementation((_cmd, _opts, callback) => {
+        overallCalls++;
+        if (typeof callback === 'function') {
+          if (overallCalls < 2) {
+            callback(new Error('Failed'), { stdout: '', stderr: '' });
+          } else {
+            callback(null, { stdout: 'OK', stderr: '' });
+          }
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const options: GateRunOptions = {
+        cwd: '/test',
+        maxRetries: 3,
+      };
+
+      const result = await runner.runWithAutoRetry(gates, options);
+
+      expect(result.allPassed).toBe(true);
+    });
+
+    it('should call onRetry callback on failure', async () => {
+      // runWithAutoRetry calls runAll, which calls runGate
+      // runGate itself retries maxRetries times before failing
+      // Then runWithAutoRetry retries the whole runAll
+      // So we need to fail enough times to:
+      // 1. Fail runGate's retries (maxRetries times)
+      // 2. Then onRetry is called
+      // 3. Then succeed on next overall attempt
+      let callCount = 0;
+      execMock.mockImplementation((_cmd, _opts, callback) => {
+        callCount++;
+        if (typeof callback === 'function') {
+          // With maxRetries=2:
+          // - runGate tries 2 times (calls 1-2), fails
+          // - onRetry(1, 'test') is called
+          // - runGate tries 2 times (calls 3-4), succeeds on 3rd
+          if (callCount <= 2) {
+            callback(new Error('Failed'), { stdout: '', stderr: '' });
+          } else {
+            callback(null, { stdout: 'OK', stderr: '' });
+          }
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const onRetry = vi.fn();
+      const options: GateRunOptions & { onRetry?: (attempt: number, failedGate: string) => void } = {
+        cwd: '/test',
+        maxRetries: 2,
+        onRetry,
+      };
+
+      const result = await runner.runWithAutoRetry(gates, options);
+
+      expect(onRetry).toHaveBeenCalledWith(1, 'test');
+      expect(result.allPassed).toBe(true);
+    });
+
+    it('should fail after overall max retries', async () => {
+      execMock.mockImplementation((_cmd, _opts, callback) => {
+        if (typeof callback === 'function') {
+          callback(new Error('Always fail'), { stdout: '', stderr: '' });
+        }
+        return { on: vi.fn(), stdout: null, stderr: null };
+      });
+
+      const options: GateRunOptions = {
+        cwd: '/test',
+        maxRetries: 2,
+      };
+
+      const result = await runner.runWithAutoRetry(gates, options);
+
+      expect(result.allPassed).toBe(false);
+    });
+  });
+
+  describe('DEFAULT_GATES', () => {
+    it('should have node gates defined', () => {
+      expect(DEFAULT_GATES.node).toBeDefined();
+      expect(DEFAULT_GATES.node).toHaveLength(4);
+      expect(DEFAULT_GATES.node[0]?.name).toBe('install');
+      expect(DEFAULT_GATES.node[1]?.name).toBe('test');
+      expect(DEFAULT_GATES.node[2]?.name).toBe('type');
+      expect(DEFAULT_GATES.node[3]?.name).toBe('lint');
+    });
+
+    it('should have pnpm gates defined', () => {
+      expect(DEFAULT_GATES.pnpm).toBeDefined();
+      expect(DEFAULT_GATES.pnpm).toHaveLength(4);
+      expect(DEFAULT_GATES.pnpm[0]?.command).toContain('pnpm install');
+    });
+
+    it('should have python gates defined', () => {
+      expect(DEFAULT_GATES.python).toBeDefined();
+      expect(DEFAULT_GATES.python[0]?.name).toBe('test');
+      expect(DEFAULT_GATES.python[0]?.command).toBe('pytest');
+    });
+
+    it('should mark required gates correctly', () => {
+      expect(DEFAULT_GATES.node[0]?.required).toBe(true);
+      expect(DEFAULT_GATES.node[3]?.required).toBe(false);
+    });
+  });
+
+  describe('detectProjectGates', () => {
+    it('should return pnpm gates by default', () => {
+      const gates = detectProjectGates('/some/path');
+
+      expect(gates).toEqual(DEFAULT_GATES.pnpm);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for `AIReviewGenerator.ts` (11 tests)
- Add comprehensive test coverage for `ValidationGateRunner.ts` (16 tests)  
- Add comprehensive test coverage for `Logger.ts` (8 tests)

Closes #39

## Test Coverage Added

### AIReviewGenerator (11 tests)
- Return null when no git changes detected
- Generate review summary successfully from Claude response
- Use default base branch (develop) when not specified
- Handle git command failure gracefully
- Handle Claude CLI failure gracefully
- Handle invalid JSON response from Claude
- Extract JSON from Claude response with surrounding text
- Provide defaults for missing fields in response
- Parse potential issues with file and line info
- Handle process spawn errors
- Truncate very long diffs in prompt

### ValidationGateRunner (16 tests)
- runGate: success on first attempt, retry on failure, max retries
- runGate: output truncation, default timeout
- runAll: sequential execution, stop on required gate failure
- runAll: continue on optional gate failure
- runWithAutoRetry: retry full validation, onRetry callback
- DEFAULT_GATES: node, pnpm, python gates configuration
- detectProjectGates: default project type detection

### Logger (8 tests)
- Verify logger creation with correct namespace
- Check info, error, debug methods are callable
- Validate claudetree namespace prefix
- Confirm independent loggers for different modules
- Test format string support

## Test plan
- [x] All tests pass (`pnpm test:run`)
- [x] TypeScript compilation passes (`pnpm -r exec tsc --noEmit`)
- [x] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)