### PR TITLE
test(cli): add missing tests for CLI commands

### DIFF
--- a/packages/cli/src/commands/batch.test.ts
+++ b/packages/cli/src/commands/batch.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Mock spawn
+const mockSpawn = vi.fn();
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Mock GitHubAdapter and SlackNotifier
+const mockListIssues = vi.fn();
+const mockNotifyBatch = vi.fn();
+vi.mock('@claudetree/core', () => ({
+  GitHubAdapter: vi.fn().mockImplementation(() => ({
+    listIssues: mockListIssues,
+  })),
+  SlackNotifier: vi.fn().mockImplementation(() => ({
+    notifyBatch: mockNotifyBatch,
+  })),
+}));
+
+import { batchCommand } from './batch.js';
+
+describe('batchCommand', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let originalExit: typeof process.exit;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleClearSpy: ReturnType<typeof vi.spyOn>;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'claudetree-batch-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    originalExit = process.exit;
+    process.exit = vi.fn() as never;
+    originalEnv = { ...process.env };
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleClearSpy = vi.spyOn(console, 'clear').mockImplementation(() => {});
+    mockSpawn.mockReset();
+    mockListIssues.mockReset();
+    mockNotifyBatch.mockReset();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exit = originalExit;
+    process.env = originalEnv;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleClearSpy.mockRestore();
+    vi.clearAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('when not initialized', () => {
+    it('should display error and exit with code 1', async () => {
+      const exitError = new Error('process.exit called');
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw exitError;
+      });
+
+      await expect(
+        batchCommand.parseAsync(['node', 'test', '101', '102'])
+      ).rejects.toThrow('process.exit called');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error: claudetree not initialized. Run "claudetree init" first.'
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('when initialized', () => {
+    beforeEach(async () => {
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        JSON.stringify({
+          worktreeDir: '.worktrees',
+          github: {
+            token: 'test-token',
+            owner: 'test-owner',
+            repo: 'test-repo',
+          },
+        })
+      );
+    });
+
+    describe('when no issues specified', () => {
+      it('should display error and exit with code 1', async () => {
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(batchCommand.parseAsync(['node', 'test'])).rejects.toThrow(
+          'process.exit called'
+        );
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Error: No issues specified.');
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('with issue arguments', () => {
+      it('should process provided issue numbers', async () => {
+        const mockProc = {
+          unref: vi.fn(),
+          on: vi.fn(),
+        };
+        mockSpawn.mockReturnValue(mockProc);
+
+        await batchCommand.parseAsync(['node', 'test', '101', '102', '--dry-run']);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Dry Run]')
+        );
+      });
+
+      it('should deduplicate issues', async () => {
+        await batchCommand.parseAsync([
+          'node',
+          'test',
+          '101',
+          '101',
+          '102',
+          '--dry-run',
+        ]);
+
+        // Should show only 2 unique issues
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('101');
+        expect(logCalls).toContain('102');
+      });
+    });
+
+    describe('with --file option', () => {
+      it('should read issues from file', async () => {
+        const issuesFile = join(testDir, 'issues.txt');
+        await writeFile(issuesFile, '101\n102\n103\n');
+
+        await batchCommand.parseAsync([
+          'node',
+          'test',
+          '--file',
+          issuesFile,
+          '--dry-run',
+        ]);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Dry Run]')
+        );
+      });
+
+      it('should ignore comments in file', async () => {
+        const issuesFile = join(testDir, 'issues.txt');
+        await writeFile(issuesFile, '# comment\n101\n102\n');
+
+        await batchCommand.parseAsync([
+          'node',
+          'test',
+          '--file',
+          issuesFile,
+          '--dry-run',
+        ]);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).not.toContain('comment');
+      });
+
+      it('should error when file not found', async () => {
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          batchCommand.parseAsync([
+            'node',
+            'test',
+            '--file',
+            'nonexistent.txt',
+          ])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error reading file: nonexistent.txt'
+        );
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('with --label option', () => {
+      it('should fetch issues from GitHub by label', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101 },
+          { number: 102 },
+          { number: 103 },
+        ]);
+
+        await batchCommand.parseAsync([
+          'node',
+          'test',
+          '--label',
+          'bug',
+          '--dry-run',
+        ]);
+
+        expect(mockListIssues).toHaveBeenCalledWith('test-owner', 'test-repo', {
+          labels: 'bug',
+          state: 'open',
+        });
+      });
+
+      it('should error when GitHub config is missing', async () => {
+        await writeFile(
+          join(testDir, '.claudetree', 'config.json'),
+          JSON.stringify({ worktreeDir: '.worktrees' })
+        );
+        delete process.env.GITHUB_TOKEN;
+
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          batchCommand.parseAsync(['node', 'test', '--label', 'bug'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error: GitHub token and repo config required for --label'
+        );
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('with --limit option', () => {
+      it('should limit number of issues processed', async () => {
+        await batchCommand.parseAsync([
+          'node',
+          'test',
+          '101',
+          '102',
+          '103',
+          '104',
+          '105',
+          '--limit',
+          '3',
+          '--dry-run',
+        ]);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Limiting to 3 issues')
+        );
+      });
+    });
+
+    describe('with --dry-run option', () => {
+      it('should not start sessions', async () => {
+        await batchCommand.parseAsync([
+          'node',
+          'test',
+          '101',
+          '102',
+          '--dry-run',
+        ]);
+
+        expect(mockSpawn).not.toHaveBeenCalled();
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Dry Run]')
+        );
+      });
+    });
+
+    describe('with --template option', () => {
+      it('should pass template to session start', async () => {
+        await batchCommand.parseAsync([
+          'node',
+          'test',
+          '101',
+          '--template',
+          'bugfix',
+          '--dry-run',
+        ]);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Template: bugfix')
+        );
+      });
+    });
+  });
+});

--- a/packages/cli/src/commands/bustercall.test.ts
+++ b/packages/cli/src/commands/bustercall.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Create mock functions at module scope
+const mockSpawn = vi.fn();
+const mockExec = vi.fn();
+
+// Mock child_process
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+  exec: (cmd: string, callback: (error: Error | null, result: { stdout: string; stderr: string }) => void) => {
+    mockExec(cmd).then(
+      (result: { stdout: string }) => callback(null, { stdout: result.stdout, stderr: '' }),
+      (error: Error) => callback(error, { stdout: '', stderr: '' })
+    );
+  },
+}));
+
+// Mock GitHubAdapter and SlackNotifier
+const mockListIssues = vi.fn();
+const mockNotifyBatch = vi.fn();
+vi.mock('@claudetree/core', () => ({
+  GitHubAdapter: vi.fn().mockImplementation(() => ({
+    listIssues: mockListIssues,
+  })),
+  SlackNotifier: vi.fn().mockImplementation(() => ({
+    notifyBatch: mockNotifyBatch,
+  })),
+}));
+
+import { bustercallCommand } from './bustercall.js';
+
+describe('bustercallCommand', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let originalExit: typeof process.exit;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleClearSpy: ReturnType<typeof vi.spyOn>;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'claudetree-bustercall-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    originalExit = process.exit;
+    process.exit = vi.fn() as never;
+    originalEnv = { ...process.env };
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleClearSpy = vi.spyOn(console, 'clear').mockImplementation(() => {});
+    mockSpawn.mockReset();
+    mockListIssues.mockReset();
+    mockNotifyBatch.mockReset();
+    mockExec.mockReset();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exit = originalExit;
+    process.env = originalEnv;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleClearSpy.mockRestore();
+    vi.clearAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('when not initialized', () => {
+    it('should display error and exit with code 1', async () => {
+      const exitError = new Error('process.exit called');
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw exitError;
+      });
+
+      await expect(bustercallCommand.parseAsync(['node', 'test'])).rejects.toThrow(
+        'process.exit called'
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error: claudetree not initialized. Run "claudetree init" first.'
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('when initialized without GitHub config', () => {
+    beforeEach(async () => {
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        JSON.stringify({ worktreeDir: '.worktrees' })
+      );
+      delete process.env.GITHUB_TOKEN;
+    });
+
+    it('should display error about missing GitHub config', async () => {
+      const exitError = new Error('process.exit called');
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw exitError;
+      });
+
+      await expect(bustercallCommand.parseAsync(['node', 'test'])).rejects.toThrow(
+        'process.exit called'
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error: GitHub configuration required for bustercall.'
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('when initialized with GitHub config', () => {
+    beforeEach(async () => {
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        JSON.stringify({
+          worktreeDir: '.worktrees',
+          github: {
+            token: 'test-token',
+            owner: 'test-owner',
+            repo: 'test-repo',
+          },
+        })
+      );
+      // Mock gh pr list
+      mockExec.mockResolvedValue({ stdout: '[]' });
+    });
+
+    describe('when no issues found', () => {
+      it('should exit with message', async () => {
+        mockListIssues.mockResolvedValue([]);
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation((code) => {
+          if (code === 0) throw exitError;
+        });
+
+        await expect(bustercallCommand.parseAsync(['node', 'test'])).rejects.toThrow(
+          'process.exit called'
+        );
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'No open issues found matching criteria.'
+        );
+        expect(process.exit).toHaveBeenCalledWith(0);
+      });
+    });
+
+    describe('with --dry-run option', () => {
+      it('should show issues without starting sessions', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Fix bug A', labels: [] },
+          { number: 102, title: 'Fix bug B', labels: [] },
+        ]);
+
+        await bustercallCommand.parseAsync(['node', 'test', '--dry-run']);
+
+        expect(mockSpawn).not.toHaveBeenCalled();
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Dry Run]')
+        );
+      });
+
+      it('should categorize issues by conflict potential', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Fix bug A', labels: [] },
+          { number: 102, title: 'Update package.json', labels: ['dependencies'] },
+        ]);
+
+        await bustercallCommand.parseAsync(['node', 'test', '--dry-run']);
+
+        // Safe issues should be shown
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('#101');
+        expect(logCalls).toContain('#102');
+      });
+    });
+
+    describe('with --label option', () => {
+      it('should filter issues by label', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Bug fix', labels: ['bug'] },
+        ]);
+
+        await bustercallCommand.parseAsync(['node', 'test', '--label', 'bug', '--dry-run']);
+
+        expect(mockListIssues).toHaveBeenCalledWith('test-owner', 'test-repo', {
+          labels: 'bug',
+          state: 'open',
+        });
+      });
+    });
+
+    describe('with --exclude option', () => {
+      it('should exclude specified issue numbers', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Fix bug A', labels: [] },
+          { number: 102, title: 'Fix bug B', labels: [] },
+          { number: 103, title: 'Fix bug C', labels: [] },
+        ]);
+
+        await bustercallCommand.parseAsync([
+          'node',
+          'test',
+          '--exclude',
+          '102',
+          '--dry-run',
+        ]);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('#101');
+        expect(logCalls).not.toContain('Fix bug B');
+        expect(logCalls).toContain('#103');
+      });
+    });
+
+    describe('with --limit option', () => {
+      it('should limit number of issues', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Fix A', labels: [] },
+          { number: 102, title: 'Fix B', labels: [] },
+          { number: 103, title: 'Fix C', labels: [] },
+          { number: 104, title: 'Fix D', labels: [] },
+        ]);
+
+        await bustercallCommand.parseAsync([
+          'node',
+          'test',
+          '--limit',
+          '2',
+          '--dry-run',
+        ]);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Found 4 issues, limiting to 2')
+        );
+      });
+    });
+
+    describe('with --sequential option', () => {
+      it('should indicate sequential execution in dry-run', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Fix A', labels: [] },
+          { number: 102, title: 'Fix B', labels: [] },
+        ]);
+
+        await bustercallCommand.parseAsync([
+          'node',
+          'test',
+          '--sequential',
+          '--dry-run',
+        ]);
+
+        // In sequential mode, all issues are processed
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('#101');
+        expect(logCalls).toContain('#102');
+      });
+    });
+
+    describe('PR filtering', () => {
+      it('should skip issues with existing PRs', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Fix A', labels: [] },
+          { number: 102, title: 'Fix B', labels: [] },
+        ]);
+        // Mock gh pr list to return PR referencing issue 102
+        mockExec.mockResolvedValue({
+          stdout: JSON.stringify([
+            { number: 1, title: 'PR for #102', body: 'Fixes #102' },
+          ]),
+        });
+
+        await bustercallCommand.parseAsync(['node', 'test', '--dry-run']);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Skipped 1 issue(s) with existing PRs')
+        );
+      });
+    });
+
+    describe('conflict detection', () => {
+      it('should detect issues with config-related labels', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Add feature', labels: [] },
+          { number: 102, title: 'Update deps', labels: ['dependencies'] },
+        ]);
+
+        await bustercallCommand.parseAsync(['node', 'test', '--dry-run']);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('Potential Conflict');
+      });
+
+      it('should detect issues with config keywords in title', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Update package.json', labels: [] },
+          { number: 102, title: 'Fix bug in login', labels: [] },
+        ]);
+
+        await bustercallCommand.parseAsync(['node', 'test', '--dry-run']);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('Potential Conflict');
+      });
+    });
+
+    describe('with --template option', () => {
+      it('should pass template for dry-run display', async () => {
+        mockListIssues.mockResolvedValue([
+          { number: 101, title: 'Fix bug', labels: [] },
+        ]);
+
+        await bustercallCommand.parseAsync([
+          'node',
+          'test',
+          '--template',
+          'bugfix',
+          '--dry-run',
+        ]);
+
+        // Template is used when starting sessions, not shown in dry-run
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Dry Run]')
+        );
+      });
+    });
+  });
+});

--- a/packages/cli/src/commands/chain.test.ts
+++ b/packages/cli/src/commands/chain.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, readFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Mock spawn
+const mockSpawn = vi.fn();
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Mock crypto for consistent UUIDs in tests
+vi.mock('node:crypto', () => ({
+  randomUUID: () => 'test-uuid-1234',
+}));
+
+import { chainCommand } from './chain.js';
+
+describe('chainCommand', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let originalExit: typeof process.exit;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleClearSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'claudetree-chain-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    originalExit = process.exit;
+    process.exit = vi.fn() as never;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleClearSpy = vi.spyOn(console, 'clear').mockImplementation(() => {});
+    mockSpawn.mockReset();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exit = originalExit;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleClearSpy.mockRestore();
+    vi.clearAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('when not initialized', () => {
+    it('should display error and exit with code 1', async () => {
+      const exitError = new Error('process.exit called');
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw exitError;
+      });
+
+      await expect(
+        chainCommand.parseAsync(['node', 'test', '10', '11', '12'])
+      ).rejects.toThrow('process.exit called');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error: claudetree not initialized. Run "claudetree init" first.'
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('when initialized', () => {
+    beforeEach(async () => {
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        JSON.stringify({
+          worktreeDir: '.worktrees',
+          github: {
+            token: 'test-token',
+            owner: 'test-owner',
+            repo: 'test-repo',
+          },
+        })
+      );
+    });
+
+    describe('with insufficient issues', () => {
+      it('should error when only one issue provided', async () => {
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          chainCommand.parseAsync(['node', 'test', '10'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error: Chain requires at least 2 issues.'
+        );
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('with --dry-run option', () => {
+      it('should show chain plan without executing', async () => {
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          '10',
+          '11',
+          '12',
+          '--dry-run',
+        ]);
+
+        expect(mockSpawn).not.toHaveBeenCalled();
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Dry Run]')
+        );
+      });
+
+      it('should display issues in order with branch info', async () => {
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          '10',
+          '11',
+          '--dry-run',
+        ]);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('#10');
+        expect(logCalls).toContain('#11');
+        expect(logCalls).toContain('issue-10');
+        expect(logCalls).toContain('issue-11');
+      });
+
+      it('should show base branch for first issue', async () => {
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          '10',
+          '11',
+          '--dry-run',
+          '--base-branch',
+          'main',
+        ]);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('main');
+      });
+
+      it('should show dependency relationships', async () => {
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          '10',
+          '11',
+          '12',
+          '--dry-run',
+        ]);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        // Second issue should base on first
+        expect(logCalls).toContain('issue-10');
+        // Third issue should base on second
+        expect(logCalls).toContain('issue-11');
+      });
+    });
+
+    describe('with --base-branch option', () => {
+      it('should use custom base branch', async () => {
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          '10',
+          '11',
+          '--base-branch',
+          'main',
+          '--dry-run',
+        ]);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('main');
+      });
+    });
+
+    describe('with --template option', () => {
+      it('should include template in output', async () => {
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          '10',
+          '11',
+          '--template',
+          'bugfix',
+          '--dry-run',
+        ]);
+
+        // Template is passed to session start, not necessarily shown in dry-run
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Dry Run]')
+        );
+      });
+    });
+
+    describe('branch name generation', () => {
+      it('should generate branch names from issue numbers', async () => {
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          '101',
+          '102',
+          '--dry-run',
+        ]);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('issue-101');
+        expect(logCalls).toContain('issue-102');
+      });
+
+      it('should sanitize non-numeric issue names', async () => {
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          'feature-auth',
+          'feature-dashboard',
+          '--dry-run',
+        ]);
+
+        const logCalls = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(logCalls).toContain('feature-auth');
+        expect(logCalls).toContain('feature-dashboard');
+      });
+    });
+
+    describe('chain state persistence', () => {
+      it('should create chains directory for non-dry-run', async () => {
+        // Setup mock for spawn
+        const mockProc = {
+          unref: vi.fn(),
+          on: vi.fn(),
+        };
+        mockSpawn.mockReturnValue(mockProc);
+
+        // Mock session creation by writing to sessions.json
+        await writeFile(
+          join(testDir, '.claudetree', 'sessions.json'),
+          JSON.stringify([
+            { issueNumber: 10, status: 'completed', id: 'session-1' },
+            { issueNumber: 11, status: 'completed', id: 'session-2' },
+          ])
+        );
+
+        // We can't easily test the full execution because it requires
+        // waiting for sessions, so we just verify dry-run works
+        await chainCommand.parseAsync([
+          'node',
+          'test',
+          '10',
+          '11',
+          '--dry-run',
+        ]);
+
+        // In dry-run, chains dir is not created
+        await expect(
+          access(join(testDir, '.claudetree', 'chains'))
+        ).rejects.toThrow();
+      });
+    });
+  });
+});

--- a/packages/cli/src/commands/chain.test.ts
+++ b/packages/cli/src/commands/chain.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile, readFile, access } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/packages/cli/src/commands/clean.test.ts
+++ b/packages/cli/src/commands/clean.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Mock readline
+const mockQuestion = vi.fn();
+const mockRlClose = vi.fn();
+vi.mock('node:readline', () => ({
+  createInterface: () => ({
+    question: mockQuestion,
+    close: mockRlClose,
+  }),
+}));
+
+// Mock GitWorktreeAdapter
+const mockWorktreeList = vi.fn();
+const mockWorktreeRemove = vi.fn();
+const mockWorktreePrune = vi.fn();
+const mockSessionFindAll = vi.fn();
+const mockSessionDelete = vi.fn();
+
+vi.mock('@claudetree/core', () => ({
+  GitWorktreeAdapter: vi.fn().mockImplementation(() => ({
+    list: mockWorktreeList,
+    remove: mockWorktreeRemove,
+    prune: mockWorktreePrune,
+  })),
+  FileSessionRepository: vi.fn().mockImplementation(() => ({
+    findAll: mockSessionFindAll,
+    delete: mockSessionDelete,
+  })),
+}));
+
+import { cleanCommand } from './clean.js';
+
+describe('cleanCommand', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let originalExit: typeof process.exit;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'claudetree-clean-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    originalExit = process.exit;
+    process.exit = vi.fn() as never;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    mockWorktreeList.mockReset();
+    mockWorktreeRemove.mockReset();
+    mockWorktreePrune.mockReset();
+    mockSessionFindAll.mockReset();
+    mockSessionDelete.mockReset();
+    mockQuestion.mockReset();
+    mockRlClose.mockReset();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exit = originalExit;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    vi.clearAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('when no worktrees to remove', () => {
+    it('should display message and return', async () => {
+      mockWorktreeList.mockResolvedValue([
+        { path: '/main', branch: 'main', isMainWorktree: true },
+      ]);
+
+      await cleanCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('No worktrees to remove.');
+      expect(mockWorktreeRemove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when worktrees exist', () => {
+    beforeEach(() => {
+      mockWorktreeList.mockResolvedValue([
+        { path: '/main', branch: 'main', isMainWorktree: true },
+        { path: '/worktree-1', branch: 'feature-1', isMainWorktree: false },
+        { path: '/worktree-2', branch: 'feature-2', isMainWorktree: false },
+      ]);
+      mockSessionFindAll.mockResolvedValue([]);
+      mockWorktreePrune.mockResolvedValue(undefined);
+    });
+
+    describe('with --dry-run option', () => {
+      it('should show worktrees without removing', async () => {
+        await cleanCommand.parseAsync(['node', 'test', '--dry-run']);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Found 2 worktree(s) to remove')
+        );
+        expect(consoleLogSpy).toHaveBeenCalledWith('\n[Dry run] No changes made.');
+        expect(mockWorktreeRemove).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('with --force option', () => {
+      it('should remove worktrees without confirmation', async () => {
+        mockWorktreeRemove.mockResolvedValue(undefined);
+
+        await cleanCommand.parseAsync(['node', 'test', '--force']);
+
+        expect(mockQuestion).not.toHaveBeenCalled();
+        expect(mockWorktreeRemove).toHaveBeenCalledTimes(2);
+        expect(mockWorktreeRemove).toHaveBeenCalledWith('/worktree-1', true);
+        expect(mockWorktreeRemove).toHaveBeenCalledWith('/worktree-2', true);
+      });
+
+      it('should report success count', async () => {
+        mockWorktreeRemove.mockResolvedValue(undefined);
+
+        await cleanCommand.parseAsync(['node', 'test', '--force']);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Removed 2 worktree(s) successfully')
+        );
+      });
+
+      it('should handle removal errors gracefully', async () => {
+        mockWorktreeRemove
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error('Permission denied'));
+
+        await cleanCommand.parseAsync(['node', 'test', '--force']);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Removed 1 worktree(s) successfully')
+        );
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to remove 1 worktree(s)')
+        );
+      });
+    });
+
+    describe('without --force option', () => {
+      it('should ask for confirmation', async () => {
+        mockQuestion.mockImplementation(
+          (
+            _msg: string,
+            cb: (answer: string) => void
+          ) => {
+            cb('n');
+          }
+        );
+
+        await cleanCommand.parseAsync(['node', 'test']);
+
+        expect(mockQuestion).toHaveBeenCalled();
+        expect(consoleLogSpy).toHaveBeenCalledWith('Cancelled.');
+        expect(mockWorktreeRemove).not.toHaveBeenCalled();
+      });
+
+      it('should remove on confirmation (y)', async () => {
+        mockQuestion.mockImplementation(
+          (
+            _msg: string,
+            cb: (answer: string) => void
+          ) => {
+            cb('y');
+          }
+        );
+        mockWorktreeRemove.mockResolvedValue(undefined);
+
+        await cleanCommand.parseAsync(['node', 'test']);
+
+        expect(mockWorktreeRemove).toHaveBeenCalledTimes(2);
+      });
+
+      it('should remove on confirmation (yes)', async () => {
+        mockQuestion.mockImplementation(
+          (
+            _msg: string,
+            cb: (answer: string) => void
+          ) => {
+            cb('yes');
+          }
+        );
+        mockWorktreeRemove.mockResolvedValue(undefined);
+
+        await cleanCommand.parseAsync(['node', 'test']);
+
+        expect(mockWorktreeRemove).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('session cleanup', () => {
+      it('should delete sessions for removed worktrees', async () => {
+        await mkdir(join(testDir, '.claudetree'), { recursive: true });
+        mockWorktreeRemove.mockResolvedValue(undefined);
+        mockSessionFindAll.mockResolvedValue([
+          { id: 'session-1', worktreePath: '/worktree-1' },
+          { id: 'session-2', worktreePath: '/worktree-2' },
+          { id: 'session-3', worktreePath: '/other-path' },
+        ]);
+
+        await cleanCommand.parseAsync(['node', 'test', '--force']);
+
+        expect(mockSessionDelete).toHaveBeenCalledTimes(2);
+        expect(mockSessionDelete).toHaveBeenCalledWith('session-1');
+        expect(mockSessionDelete).toHaveBeenCalledWith('session-2');
+      });
+
+      it('should not delete sessions with --keep-sessions', async () => {
+        mockWorktreeRemove.mockResolvedValue(undefined);
+        mockSessionFindAll.mockResolvedValue([
+          { id: 'session-1', worktreePath: '/worktree-1' },
+        ]);
+
+        await cleanCommand.parseAsync(['node', 'test', '--force', '--keep-sessions']);
+
+        expect(mockSessionDelete).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('prune operation', () => {
+      it('should prune stale entries after removal', async () => {
+        mockWorktreeRemove.mockResolvedValue(undefined);
+
+        await cleanCommand.parseAsync(['node', 'test', '--force']);
+
+        expect(mockWorktreePrune).toHaveBeenCalled();
+      });
+
+      it('should handle prune errors gracefully', async () => {
+        mockWorktreeRemove.mockResolvedValue(undefined);
+        mockWorktreePrune.mockRejectedValue(new Error('Prune failed'));
+
+        await cleanCommand.parseAsync(['node', 'test', '--force']);
+
+        // Should not throw, prune failure is handled
+        expect(stdoutWriteSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Pruning stale entries')
+        );
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle list errors', async () => {
+      mockWorktreeList.mockRejectedValue(new Error('List failed'));
+      (process.exit as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+
+      await expect(cleanCommand.parseAsync(['node', 'test'])).rejects.toThrow(
+        'process.exit called'
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error: List failed');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/packages/cli/src/commands/clean.test.ts
+++ b/packages/cli/src/commands/clean.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -50,7 +50,7 @@ describe('cleanCommand', () => {
     process.exit = vi.fn() as never;
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true) as ReturnType<typeof vi.spyOn>;
     mockWorktreeList.mockReset();
     mockWorktreeRemove.mockReset();
     mockWorktreePrune.mockReset();

--- a/packages/cli/src/commands/demo.test.ts
+++ b/packages/cli/src/commands/demo.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { demoCommand } from './demo.js';
+
+describe('demoCommand', () => {
+  describe('command structure', () => {
+    it('should have correct name', () => {
+      expect(demoCommand.name()).toBe('demo');
+    });
+
+    it('should have correct description', () => {
+      expect(demoCommand.description()).toContain('Interactive demo');
+      expect(demoCommand.description()).toContain('no tokens');
+    });
+
+    it('should not require arguments', () => {
+      // Demo command has no required arguments
+      const args = demoCommand.registeredArguments;
+      expect(args).toHaveLength(0);
+    });
+
+    it('should not have options', () => {
+      // Demo command has no options
+      const options = demoCommand.options;
+      expect(options).toHaveLength(0);
+    });
+  });
+
+  describe('command definition', () => {
+    it('should be a Command instance', () => {
+      expect(demoCommand).toBeDefined();
+      expect(typeof demoCommand.parseAsync).toBe('function');
+    });
+
+    it('should have action handler', () => {
+      // Commander stores action in _actionHandler
+      expect((demoCommand as unknown as { _actionHandler: unknown })._actionHandler).toBeDefined();
+    });
+  });
+});

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Mock execSync
+const mockExecSync = vi.fn();
+vi.mock('node:child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+import { doctorCommand } from './doctor.js';
+
+describe('doctorCommand', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let originalExit: typeof process.exit;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'claudetree-doctor-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    originalExit = process.exit;
+    process.exit = vi.fn() as never;
+    originalEnv = { ...process.env };
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockExecSync.mockReset();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exit = originalExit;
+    process.env = originalEnv;
+    consoleLogSpy.mockRestore();
+    vi.clearAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('Node.js check', () => {
+    it('should pass for Node.js >= 18', async () => {
+      // Setup mocks
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Node.js')
+      );
+    });
+  });
+
+  describe('Git Repository check', () => {
+    it('should pass when inside git repo', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Git Repository')
+      );
+    });
+
+    it('should fail when not inside git repo', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') {
+          throw new Error('not a git repository');
+        }
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+
+      await expect(doctorCommand.parseAsync(['node', 'test'])).rejects.toThrow(
+        'process.exit called'
+      );
+
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('Claude CLI check', () => {
+    it('should pass when Claude CLI is installed', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0\nsome other info';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Claude CLI')
+      );
+    });
+
+    it('should fail when Claude CLI is not installed', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') throw new Error('command not found');
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+
+      await expect(doctorCommand.parseAsync(['node', 'test'])).rejects.toThrow(
+        'process.exit called'
+      );
+
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('GitHub CLI check', () => {
+    it('should pass (warn) when gh CLI is installed', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.40.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('GitHub CLI')
+      );
+    });
+
+    it('should warn when gh CLI is not installed', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') throw new Error('command not found');
+        if (cmd === 'gh auth status') throw new Error('not authenticated');
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      // gh CLI missing is a warning, not a failure
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('GitHub CLI')
+      );
+    });
+  });
+
+  describe('GitHub Auth check', () => {
+    it('should pass when gh is authenticated', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return 'Logged in as user';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('GitHub Auth')
+      );
+    });
+
+    it('should pass when GITHUB_TOKEN is set', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') throw new Error('not authenticated');
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('GitHub Auth')
+      );
+    });
+  });
+
+  describe('claudetree Init check', () => {
+    it('should pass when initialized', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('claudetree Init')
+      );
+    });
+
+    it('should fail when not initialized', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+
+      await expect(doctorCommand.parseAsync(['node', 'test'])).rejects.toThrow(
+        'process.exit called'
+      );
+
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('Anthropic API Key check', () => {
+    it('should pass when ANTHROPIC_API_KEY is set', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-12345678901234567890';
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Anthropic API Key')
+      );
+    });
+
+    it('should warn when ANTHROPIC_API_KEY is not set', async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      // Missing API key is a warning, not failure
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Anthropic API Key')
+      );
+    });
+  });
+
+  describe('--quiet option', () => {
+    it('should only show failures and warnings', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+      delete process.env.ANTHROPIC_API_KEY;
+
+      await doctorCommand.parseAsync(['node', 'test', '--quiet']);
+
+      // In quiet mode, only warnings/failures should be logged
+      // Check that it completes without error
+      expect(process.exit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('summary output', () => {
+    it('should display ready message when all pass', async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git rev-parse --git-dir') return '.git';
+        if (cmd === 'claude --version') return 'claude 1.0.0';
+        if (cmd === 'gh --version') return 'gh version 2.0.0';
+        if (cmd === 'gh auth status') return '';
+        throw new Error(`Unknown command: ${cmd}`);
+      });
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+      process.env.GITHUB_TOKEN = 'test-token';
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claudetree', 'config.json'),
+        '{}'
+      );
+
+      await doctorCommand.parseAsync(['node', 'test']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Ready to use claudetree')
+      );
+    });
+  });
+});

--- a/packages/cli/src/commands/resume.test.ts
+++ b/packages/cli/src/commands/resume.test.ts
@@ -1,0 +1,464 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Session } from '@claudetree/shared';
+
+// Mock FileSessionRepository, FileEventRepository, and ClaudeSessionAdapter
+const mockFindAll = vi.fn();
+const mockSave = vi.fn();
+const mockEventAppend = vi.fn();
+const mockResume = vi.fn();
+const mockGetOutput = vi.fn();
+const mockOn = vi.fn();
+
+vi.mock('@claudetree/core', () => ({
+  FileSessionRepository: vi.fn().mockImplementation(() => ({
+    findAll: mockFindAll,
+    save: mockSave,
+  })),
+  FileEventRepository: vi.fn().mockImplementation(() => ({
+    append: mockEventAppend,
+  })),
+  ClaudeSessionAdapter: vi.fn().mockImplementation(() => ({
+    resume: mockResume,
+    getOutput: mockGetOutput,
+    on: mockOn,
+  })),
+}));
+
+import { resumeCommand } from './resume.js';
+
+describe('resumeCommand', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let originalExit: typeof process.exit;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  const createMockSession = (overrides: Partial<Session> = {}): Session => ({
+    id: 'test-session-id-12345678',
+    worktreeId: 'worktree-id-456',
+    claudeSessionId: 'claude-session-123',
+    status: 'paused',
+    issueNumber: 42,
+    prompt: 'Fix the bug',
+    createdAt: new Date('2024-01-15'),
+    updatedAt: new Date('2024-01-15'),
+    processId: null,
+    osProcessId: null,
+    lastHeartbeat: null,
+    errorCount: 0,
+    worktreePath: '/path/to/worktree',
+    usage: null,
+    progress: null,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'claudetree-resume-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    originalExit = process.exit;
+    process.exit = vi.fn() as never;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFindAll.mockReset();
+    mockSave.mockReset();
+    mockEventAppend.mockReset();
+    mockResume.mockReset();
+    mockGetOutput.mockReset();
+    mockOn.mockReset();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exit = originalExit;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    vi.clearAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('when not initialized', () => {
+    it('should display error and exit with code 1', async () => {
+      const exitError = new Error('process.exit called');
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw exitError;
+      });
+
+      await expect(
+        resumeCommand.parseAsync(['node', 'test', 'test-ses'])
+      ).rejects.toThrow('process.exit called');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error: claudetree not initialized. Run "claudetree init" first.'
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('when initialized', () => {
+    beforeEach(async () => {
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+    });
+
+    describe('when no matching session found', () => {
+      it('should display error and exit with code 1', async () => {
+        mockFindAll.mockResolvedValue([
+          createMockSession({ id: 'other-session-id', status: 'completed' }),
+        ]);
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          resumeCommand.parseAsync(['node', 'test', 'nonexistent'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'No resumable session found matching: nonexistent'
+        );
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+
+      it('should list resumable sessions when no match', async () => {
+        const pausedSession = createMockSession({
+          id: 'paused-session-123',
+          status: 'paused',
+          issueNumber: 42,
+        });
+        mockFindAll.mockResolvedValue([pausedSession]);
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          resumeCommand.parseAsync(['node', 'test', 'nonexistent'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          '\nResumable sessions (paused/running):'
+        );
+      });
+    });
+
+    describe('when session has no Claude session ID', () => {
+      it('should display error and exit with code 1', async () => {
+        const session = createMockSession({
+          id: 'test-session-123',
+          claudeSessionId: null,
+          status: 'paused',
+        });
+        mockFindAll.mockResolvedValue([session]);
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          resumeCommand.parseAsync(['node', 'test', 'test-ses'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error: Session has no Claude session ID. Cannot resume.'
+        );
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('when session has no worktree path', () => {
+      it('should display error and exit with code 1', async () => {
+        const session = createMockSession({
+          id: 'test-session-123',
+          claudeSessionId: 'claude-123',
+          worktreePath: null,
+          status: 'paused',
+        });
+        mockFindAll.mockResolvedValue([session]);
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          resumeCommand.parseAsync(['node', 'test', 'test-ses'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error: Session has no worktree path. Cannot resume.'
+        );
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('when worktree does not exist', () => {
+      it('should display error and exit with code 1', async () => {
+        const session = createMockSession({
+          id: 'test-session-123',
+          claudeSessionId: 'claude-123',
+          worktreePath: '/nonexistent/path',
+          status: 'paused',
+        });
+        mockFindAll.mockResolvedValue([session]);
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          resumeCommand.parseAsync(['node', 'test', 'test-ses'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error: Worktree no longer exists: /nonexistent/path'
+        );
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('when session can be resumed', () => {
+      let worktreePath: string;
+
+      beforeEach(async () => {
+        worktreePath = join(testDir, 'worktree');
+        await mkdir(worktreePath, { recursive: true });
+      });
+
+      it('should find session by ID prefix', async () => {
+        const session = createMockSession({
+          id: 'test-session-abc12345',
+          claudeSessionId: 'claude-123',
+          worktreePath,
+          status: 'paused',
+        });
+        mockFindAll.mockResolvedValue([session]);
+        mockResume.mockResolvedValue({
+          processId: 'proc-1',
+          osProcessId: 12345,
+        });
+
+        // Mock getOutput to return async iterator
+        mockGetOutput.mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'done', content: 'session-id' };
+          },
+        });
+
+        await resumeCommand.parseAsync(['node', 'test', 'test-ses']);
+
+        expect(mockResume).toHaveBeenCalledWith(
+          'claude-123',
+          'Continue from where you left off.'
+        );
+      });
+
+      it('should use custom prompt with --prompt option', async () => {
+        const session = createMockSession({
+          id: 'test-session-abc12345',
+          claudeSessionId: 'claude-123',
+          worktreePath,
+          status: 'paused',
+        });
+        mockFindAll.mockResolvedValue([session]);
+        mockResume.mockResolvedValue({
+          processId: 'proc-1',
+          osProcessId: 12345,
+        });
+
+        mockGetOutput.mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'done', content: 'session-id' };
+          },
+        });
+
+        await resumeCommand.parseAsync([
+          'node',
+          'test',
+          'test-ses',
+          '--prompt',
+          'Continue with the tests',
+        ]);
+
+        expect(mockResume).toHaveBeenCalledWith(
+          'claude-123',
+          'Continue with the tests'
+        );
+      });
+
+      it('should update session with process info', async () => {
+        const session = createMockSession({
+          id: 'test-session-abc12345',
+          claudeSessionId: 'claude-123',
+          worktreePath,
+          status: 'paused',
+        });
+        mockFindAll.mockResolvedValue([session]);
+        mockResume.mockResolvedValue({
+          processId: 'proc-1',
+          osProcessId: 12345,
+        });
+
+        mockGetOutput.mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'done', content: 'session-id' };
+          },
+        });
+
+        await resumeCommand.parseAsync(['node', 'test', 'test-ses']);
+
+        // Check that save was called with processId and osProcessId
+        expect(mockSave).toHaveBeenCalled();
+        const savedSession = mockSave.mock.calls[0][0];
+        expect(savedSession.processId).toBe('proc-1');
+        expect(savedSession.osProcessId).toBe(12345);
+      });
+
+      it('should mark session as completed when done', async () => {
+        const session = createMockSession({
+          id: 'test-session-abc12345',
+          claudeSessionId: 'claude-123',
+          worktreePath,
+          status: 'paused',
+        });
+        mockFindAll.mockResolvedValue([session]);
+        mockResume.mockResolvedValue({
+          processId: 'proc-1',
+          osProcessId: 12345,
+        });
+
+        mockGetOutput.mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'done', content: 'new-session-id' };
+          },
+        });
+
+        await resumeCommand.parseAsync(['node', 'test', 'test-ses']);
+
+        // Last save should be completed
+        const lastSaveCall = mockSave.mock.calls[mockSave.mock.calls.length - 1];
+        expect(lastSaveCall[0].status).toBe('completed');
+      });
+
+      it('should display output logs', async () => {
+        const session = createMockSession({
+          id: 'test-session-abc12345',
+          claudeSessionId: 'claude-123',
+          worktreePath,
+          status: 'paused',
+        });
+        mockFindAll.mockResolvedValue([session]);
+        mockResume.mockResolvedValue({
+          processId: 'proc-1',
+          osProcessId: 12345,
+        });
+
+        mockGetOutput.mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'text', content: 'Working on the task...' };
+            yield { type: 'tool_use', content: 'Reading file' };
+            yield { type: 'done', content: 'session-id' };
+          },
+        });
+
+        await resumeCommand.parseAsync(['node', 'test', 'test-ses']);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('Working on the task...');
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Tool]')
+        );
+      });
+    });
+
+    describe('session matching', () => {
+      it('should match paused sessions', async () => {
+        const pausedSession = createMockSession({
+          id: 'paused-session-123',
+          status: 'paused',
+          worktreePath: testDir,
+        });
+        await mkdir(testDir, { recursive: true });
+        mockFindAll.mockResolvedValue([pausedSession]);
+        mockResume.mockResolvedValue({
+          processId: 'proc-1',
+          osProcessId: 12345,
+        });
+
+        mockGetOutput.mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'done', content: 'session-id' };
+          },
+        });
+
+        await resumeCommand.parseAsync(['node', 'test', 'paused']);
+
+        expect(mockResume).toHaveBeenCalled();
+      });
+
+      it('should match running sessions', async () => {
+        const runningSession = createMockSession({
+          id: 'running-session-123',
+          status: 'running',
+          worktreePath: testDir,
+        });
+        mockFindAll.mockResolvedValue([runningSession]);
+        mockResume.mockResolvedValue({
+          processId: 'proc-1',
+          osProcessId: 12345,
+        });
+
+        mockGetOutput.mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'done', content: 'session-id' };
+          },
+        });
+
+        await resumeCommand.parseAsync(['node', 'test', 'running']);
+
+        expect(mockResume).toHaveBeenCalled();
+      });
+
+      it('should not match completed sessions', async () => {
+        const completedSession = createMockSession({
+          id: 'completed-session-123',
+          status: 'completed',
+        });
+        mockFindAll.mockResolvedValue([completedSession]);
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          resumeCommand.parseAsync(['node', 'test', 'completed'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('No resumable session found')
+        );
+      });
+
+      it('should not match failed sessions', async () => {
+        const failedSession = createMockSession({
+          id: 'failed-session-123',
+          status: 'failed',
+        });
+        mockFindAll.mockResolvedValue([failedSession]);
+        const exitError = new Error('process.exit called');
+        (process.exit as unknown as Mock).mockImplementation(() => {
+          throw exitError;
+        });
+
+        await expect(
+          resumeCommand.parseAsync(['node', 'test', 'failed'])
+        ).rejects.toThrow('process.exit called');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('No resumable session found')
+        );
+      });
+    });
+  });
+});

--- a/packages/cli/src/commands/resume.test.ts
+++ b/packages/cli/src/commands/resume.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Session } from '@claudetree/shared';
@@ -311,7 +311,7 @@ describe('resumeCommand', () => {
 
         // Check that save was called with processId and osProcessId
         expect(mockSave).toHaveBeenCalled();
-        const savedSession = mockSave.mock.calls[0][0];
+        const savedSession = mockSave.mock.calls[0]![0];
         expect(savedSession.processId).toBe('proc-1');
         expect(savedSession.osProcessId).toBe(12345);
       });
@@ -338,7 +338,7 @@ describe('resumeCommand', () => {
         await resumeCommand.parseAsync(['node', 'test', 'test-ses']);
 
         // Last save should be completed
-        const lastSaveCall = mockSave.mock.calls[mockSave.mock.calls.length - 1];
+        const lastSaveCall = mockSave.mock.calls[mockSave.mock.calls.length - 1]!;
         expect(lastSaveCall[0].status).toBe('completed');
       });
 


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for 7 previously untested CLI commands
- All tests follow existing patterns using vitest and mocking

## Changes
Added tests for:
- `batch.ts` - 12 tests covering initialization, issue processing, file input, GitHub label filtering, limits, dry-run, and template options
- `bustercall.ts` - 13 tests covering GitHub config, issue filtering, PR filtering, conflict detection, sequential mode
- `chain.ts` - 11 tests covering chain validation, dry-run mode, branch name generation, base branch options
- `clean.ts` - 13 tests covering worktree removal, confirmation prompts, session cleanup, prune operations
- `demo.ts` - 6 tests covering command structure and definition (interactive demo has timing constraints)
- `doctor.ts` - 15 tests covering all environment checks (Node.js, Git, Claude CLI, GitHub, Anthropic key)
- `resume.ts` - 15 tests covering session matching, resume flow, output handling, status updates

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm test:run` - 166 CLI tests passing
- [x] `pnpm -r exec tsc --noEmit` - No type errors

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)