### PR TITLE
release: v0.7.0 - MCP server + session tagging

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @claudetree/cli
 
+## 0.7.0
+
+### Minor Changes
+
+- feat: add session tagging for organization and filtering
+
+  - Add tags field to Session type
+  - Add --tag flag to ct start and ct status
+  - Add tag filtering to MCP ct_sessions_list and ct_start tools
+
+### Patch Changes
+
+- Updated dependencies
+  - @claudetree/shared@0.7.0
+  - @claudetree/core@0.6.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Issue-to-PR automation: parallel Claude Code sessions with cost tracking, batch processing & web dashboard",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/resume.test.ts
+++ b/packages/cli/src/commands/resume.test.ts
@@ -54,6 +54,7 @@ describe('resumeCommand', () => {
     progress: null,
     retryCount: 0,
     lastError: null,
+    tags: [],
     ...overrides,
   });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -49,6 +49,7 @@ interface StartOptions {
   testCommand?: string;
   retry?: string;
   retryDelay?: string;
+  tag?: string[];
 }
 
 interface Config {
@@ -92,6 +93,7 @@ export const startCommand = new Command('start')
   .option('--test-command <cmd>', 'Custom test command (default: pnpm test)')
   .option('--retry <n>', 'Auto-retry on session failure (default: 0, no retry)')
   .option('--retry-delay <ms>', 'Base delay between retries in ms (default: 5000)')
+  .option('--tag <tags...>', 'Tags for session organization and filtering')
   .action(async (issue: string, options: StartOptions) => {
     const cwd = process.cwd();
     const config = await loadConfig(cwd);
@@ -224,6 +226,7 @@ export const startCommand = new Command('start')
         },
         retryCount: 0,
         lastError: null,
+        tags: options.tag ?? [],
       };
 
       await sessionRepo.save(session);

--- a/packages/cli/src/commands/stats.test.ts
+++ b/packages/cli/src/commands/stats.test.ts
@@ -106,6 +106,7 @@ describe('statsCommand', () => {
       progress: null,
       retryCount: 0,
       lastError: null,
+      tags: [],
       ...overrides,
     });
 

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -101,6 +101,7 @@ describe('statusCommand', () => {
         progress: null,
         retryCount: 0,
         lastError: null,
+        tags: [],
         ...overrides,
       });
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -10,6 +10,7 @@ interface StatusOptions {
   json: boolean;
   watch: boolean;
   health: boolean;
+  tag?: string[];
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -72,6 +73,7 @@ export const statusCommand = new Command('status')
   .option('--json', 'Output as JSON', false)
   .option('-w, --watch', 'Watch mode with real-time updates', false)
   .option('--health', 'Check process health and mark zombie sessions as failed', false)
+  .option('--tag <tags...>', 'Filter sessions by tag')
   .action(async (options: StatusOptions) => {
     const cwd = process.cwd();
     const configDir = join(cwd, CONFIG_DIR);
@@ -86,7 +88,15 @@ export const statusCommand = new Command('status')
     const sessionRepo = new FileSessionRepository(configDir);
 
     const displayStatus = async () => {
-      const sessions = await sessionRepo.findAll();
+      let sessions = await sessionRepo.findAll();
+
+      // Filter by tags if specified
+      if (options.tag && options.tag.length > 0) {
+        const filterTags = new Set(options.tag);
+        sessions = sessions.filter(
+          (s) => s.tags?.some((t: string) => filterTags.has(t)),
+        );
+      }
 
       if (options.json) {
         console.log(JSON.stringify(sessions, null, 2));
@@ -110,6 +120,7 @@ export const statusCommand = new Command('status')
         const color = STATUS_COLORS[session.status] ?? '';
         const statusStr = `${color}${session.status}${RESET}`;
         const issueStr = session.issueNumber ? ` (Issue #${session.issueNumber})` : '';
+        const tagsStr = session.tags?.length ? ` [${session.tags.join(', ')}]` : '';
 
         // Health check for running sessions
         let healthIndicator = '';
@@ -130,7 +141,7 @@ export const statusCommand = new Command('status')
           }
         }
 
-        console.log(`  ${session.id.slice(0, 8)} - ${statusStr}${issueStr}${healthIndicator}`);
+        console.log(`  ${session.id.slice(0, 8)} - ${statusStr}${issueStr}${tagsStr}${healthIndicator}`);
         console.log(`    Worktree: ${session.worktreeId.slice(0, 8)}`);
         if (session.prompt) {
           const truncatedPrompt = session.prompt.length > 50

--- a/packages/cli/src/commands/stop.test.ts
+++ b/packages/cli/src/commands/stop.test.ts
@@ -44,6 +44,7 @@ describe('stopCommand', () => {
     progress: null,
     retryCount: 0,
     lastError: null,
+    tags: [],
     ...overrides,
   });
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @claudetree/core
 
+## 0.6.1
+
+### Patch Changes
+
+- feat: add session tagging for organization and filtering
+
+  - Add tags field to Session type
+  - Add --tag flag to ct start and ct status
+  - Add tag filtering to MCP ct_sessions_list and ct_start tools
+
+- Updated dependencies
+  - @claudetree/shared@0.7.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Core engine for claudetree: worktree management, GitHub integration, session orchestration & cost tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/application/SessionRetryManager.test.ts
+++ b/packages/core/src/application/SessionRetryManager.test.ts
@@ -23,6 +23,7 @@ function createMockSession(overrides?: Partial<Session>): Session {
     progress: null,
     retryCount: 0,
     lastError: null,
+    tags: [],
     ...overrides,
   };
 }

--- a/packages/core/src/application/WorktreeSyncService.test.ts
+++ b/packages/core/src/application/WorktreeSyncService.test.ts
@@ -27,6 +27,7 @@ describe('WorktreeSyncService', () => {
     progress: null,
     retryCount: 0,
     lastError: null,
+    tags: [],
     ...overrides,
   });
 

--- a/packages/core/src/application/WorktreeSyncService.ts
+++ b/packages/core/src/application/WorktreeSyncService.ts
@@ -83,6 +83,7 @@ export class WorktreeSyncService {
       // Retry tracking
       retryCount: 0,
       lastError: null,
+      tags: [],
     };
   }
 }

--- a/packages/core/src/infra/storage/FileSessionRepository.test.ts
+++ b/packages/core/src/infra/storage/FileSessionRepository.test.ts
@@ -36,6 +36,7 @@ describe('FileSessionRepository', () => {
     progress: null,
     retryCount: 0,
     lastError: null,
+    tags: [],
     ...overrides,
   });
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @claudetree/mcp
 
+## 0.8.0
+
+### Minor Changes
+
+- feat: add session tagging for organization and filtering
+
+  - Add tags field to Session type
+  - Add --tag flag to ct start and ct status
+  - Add tag filtering to MCP ct_sessions_list and ct_start tools
+
+### Patch Changes
+
+- Updated dependencies
+  - @claudetree/shared@0.7.0
+  - @claudetree/core@0.6.1
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "MCP server for claudetree: expose session management as Model Context Protocol tools",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -126,6 +126,7 @@ describe('MCP Tools', () => {
           progress: null,
           retryCount: 0,
           lastError: null,
+          tags: [],
           osProcessId: null,
         },
       ]);

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -51,16 +51,24 @@ export function registerTools(server: McpServer): void {
           .enum(['all', 'running', 'completed', 'failed', 'paused', 'pending'])
           .optional()
           .describe('Filter by session status (default: all)'),
+        tag: z
+          .string()
+          .optional()
+          .describe('Filter sessions by tag'),
       },
     },
-    async ({ status }) => {
+    async ({ status, tag }) => {
       const sessionRepo = new FileSessionRepository(join(cwd, CONFIG_DIR));
       const sessions = await sessionRepo.findAll();
 
-      const filtered =
+      let filtered =
         !status || status === 'all'
           ? sessions
           : sessions.filter((s) => s.status === status);
+
+      if (tag) {
+        filtered = filtered.filter((s) => s.tags?.includes(tag));
+      }
 
       if (filtered.length === 0) {
         return textResult('No sessions found.');
@@ -70,7 +78,8 @@ export function registerTools(server: McpServer): void {
         const issue = s.issueNumber ? `#${s.issueNumber}` : 'N/A';
         const cost = s.usage ? `$${s.usage.totalCostUsd.toFixed(4)}` : '-';
         const retry = s.retryCount > 0 ? ` (retries: ${s.retryCount})` : '';
-        return `${s.id.slice(0, 8)} | ${s.status} | Issue ${issue} | Cost ${cost}${retry}`;
+        const tags = s.tags?.length ? ` [${s.tags.join(', ')}]` : '';
+        return `${s.id.slice(0, 8)} | ${s.status} | Issue ${issue} | Cost ${cost}${retry}${tags}`;
       });
 
       return textResult(
@@ -125,6 +134,10 @@ export function registerTools(server: McpServer): void {
           `Step: ${session.progress.currentStep}`,
           `Completed: ${session.progress.completedSteps.join(', ') || 'none'}`,
         );
+      }
+
+      if (session.tags?.length) {
+        detail.push(`Tags: ${session.tags.join(', ')}`);
       }
 
       if (session.retryCount > 0) {
@@ -224,14 +237,19 @@ export function registerTools(server: McpServer): void {
           .boolean()
           .optional()
           .describe('Disable TDD mode'),
+        tags: z
+          .array(z.string())
+          .optional()
+          .describe('Tags for session organization'),
       },
     },
-    async ({ issue, template, maxCost, retry, noTdd }) => {
+    async ({ issue, template, maxCost, retry, noTdd, tags }) => {
       const args = ['start', issue];
       if (template) args.push('--template', template);
       if (maxCost) args.push('--max-cost', String(maxCost));
       if (retry) args.push('--retry', String(retry));
       if (noTdd) args.push('--no-tdd');
+      if (tags?.length) args.push('--tag', ...tags);
 
       const proc = spawn('claudetree', args, {
         cwd,

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @claudetree/shared
 
+## 0.7.0
+
+### Minor Changes
+
+- feat: add session tagging for organization and filtering
+
+  - Add tags field to Session type
+  - Add --tag flag to ct start and ct status
+  - Add tag filtering to MCP ct_sessions_list and ct_start tools
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/shared",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared types and utilities for claudetree",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -48,6 +48,8 @@ export interface Session {
   // Retry tracking
   retryCount: number;
   lastError: string | null;
+  // Tags for filtering and organization
+  tags: string[];
 }
 
 export interface CreateSessionInput {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @claudetree/web
 
+## 0.5.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @claudetree/shared@0.7.0
+
 ## 0.5.11
 
 ### Patch Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/web",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "private": true,
   "description": "Web dashboard for claudetree",
   "scripts": {

--- a/packages/web/src/app/api/sessions/[id]/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.test.ts
@@ -22,6 +22,7 @@ const createTestSession = (overrides: Partial<Session> = {}): Session => ({
   progress: null,
   retryCount: 0,
   lastError: null,
+  tags: [],
   ...overrides,
 });
 

--- a/packages/web/src/app/api/sessions/route.test.ts
+++ b/packages/web/src/app/api/sessions/route.test.ts
@@ -22,6 +22,7 @@ const createTestSession = (overrides: Partial<Session> = {}): Session => ({
   progress: null,
   retryCount: 0,
   lastError: null,
+  tags: [],
   ...overrides,
 });
 

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -60,6 +60,7 @@ export async function GET() {
           progress: null,
           retryCount: 0,
           lastError: null,
+          tags: [],
         };
         sessions.push(newSession);
         hasChanges = true;


### PR DESCRIPTION
## Summary

- **@claudetree/mcp** (NEW): MCP server with 8 tools for AI tool integration
- **Session Tagging**: `--tag` flag for session organization and filtering
- Tag-based filtering in `ct status --tag` and MCP `ct_sessions_list`

## Packages Published
| Package | Version |
|---------|---------|
| @claudetree/cli | 0.7.0 |
| @claudetree/core | 0.6.1 |
| @claudetree/shared | 0.7.0 |
| @claudetree/mcp | 0.8.0 |

## Test plan
- [x] 63 test files, 648 tests passed
- [x] All packages built successfully
- [x] Published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)