### PR TITLE
release: v0.8.1/0.9.0 - budget alerts, MCP bustercall

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @claudetree/cli
 
+## 0.8.1
+
+### Patch Changes
+
+- feat: budget alerts and MCP bustercall tool
+
+  - Progressive budget alerts at 50%, 75%, 90% of --max-cost in ct start
+  - New ct_bustercall MCP tool for AI-driven issue orchestration (9 tools total)
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Issue-to-PR automation: parallel Claude Code sessions with cost tracking, batch processing & web dashboard",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -422,6 +422,7 @@ export const startCommand = new Command('start')
       let outputCount = 0;
       let currentCost = 0;
       let budgetExceeded = false;
+      const budgetAlerts = new Set<number>();
 
       for await (const output of claudeAdapter.getOutput(result.processId)) {
         outputCount++;
@@ -438,14 +439,30 @@ export const startCommand = new Command('start')
         if (output.cumulativeCost !== undefined) {
           currentCost = output.cumulativeCost;
 
-          if (options.maxCost && currentCost >= options.maxCost && !budgetExceeded) {
-            budgetExceeded = true;
-            console.log(`\x1b[31m[Budget]\x1b[0m Cost $${currentCost.toFixed(4)} exceeded limit $${options.maxCost.toFixed(4)}. Stopping...`);
-            await claudeAdapter.stop(result.processId);
-            session.status = 'failed';
-            session.updatedAt = new Date();
-            await sessionRepo.save(session);
-            break;
+          if (options.maxCost) {
+            const ratio = currentCost / options.maxCost;
+
+            // Budget warning alerts at 50%, 75%, 90%
+            if (ratio >= 0.9 && !budgetAlerts.has(90)) {
+              budgetAlerts.add(90);
+              console.log(`\x1b[31m[Budget 90%]\x1b[0m $${currentCost.toFixed(4)} / $${options.maxCost.toFixed(4)} - approaching limit!`);
+            } else if (ratio >= 0.75 && !budgetAlerts.has(75)) {
+              budgetAlerts.add(75);
+              console.log(`\x1b[33m[Budget 75%]\x1b[0m $${currentCost.toFixed(4)} / $${options.maxCost.toFixed(4)}`);
+            } else if (ratio >= 0.5 && !budgetAlerts.has(50)) {
+              budgetAlerts.add(50);
+              console.log(`\x1b[33m[Budget 50%]\x1b[0m $${currentCost.toFixed(4)} / $${options.maxCost.toFixed(4)}`);
+            }
+
+            if (currentCost >= options.maxCost && !budgetExceeded) {
+              budgetExceeded = true;
+              console.log(`\x1b[31m[Budget]\x1b[0m Cost $${currentCost.toFixed(4)} exceeded limit $${options.maxCost.toFixed(4)}. Stopping...`);
+              await claudeAdapter.stop(result.processId);
+              session.status = 'failed';
+              session.updatedAt = new Date();
+              await sessionRepo.save(session);
+              break;
+            }
           }
         }
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @claudetree/mcp
 
+## 0.9.0
+
+### Minor Changes
+
+- feat: budget alerts and MCP bustercall tool
+
+  - Progressive budget alerts at 50%, 75%, 90% of --max-cost in ct start
+  - New ct_bustercall MCP tool for AI-driven issue orchestration (9 tools total)
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "MCP server for claudetree: expose session management as Model Context Protocol tools",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -63,8 +63,9 @@ describe('MCP Tools', () => {
     expect(tools.has('ct_stop')).toBe(true);
     expect(tools.has('ct_stats')).toBe(true);
     expect(tools.has('ct_health')).toBe(true);
+    expect(tools.has('ct_bustercall')).toBe(true);
     expect(tools.has('ct_config')).toBe(true);
-    expect(tools.size).toBe(8);
+    expect(tools.size).toBe(9);
   });
 
   describe('ct_sessions_list', () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -265,6 +265,53 @@ export function registerTools(server: McpServer): void {
   );
 
   // ──────────────────────────────────────
+  // ct_bustercall - Auto-fetch and process issues
+  // ──────────────────────────────────────
+  server.registerTool(
+    'ct_bustercall',
+    {
+      description:
+        'Auto-fetch open GitHub issues, detect conflicts, and start parallel Claude sessions (bustercall/auto)',
+      inputSchema: {
+        label: z.string().optional().describe('Filter by GitHub label'),
+        limit: z.number().min(1).max(50).optional().describe('Max issues to process (default: 10)'),
+        parallel: z.number().min(1).max(10).optional().describe('Parallel session count (default: 3)'),
+        template: z
+          .enum(['bugfix', 'feature', 'refactor', 'review', 'docs'])
+          .optional()
+          .describe('Session template'),
+        dryRun: z.boolean().optional().describe('Show plan without executing'),
+        retry: z.number().min(0).max(5).optional().describe('Auto-retry failed sessions'),
+        sequential: z.boolean().optional().describe('Force sequential execution'),
+        tags: z.array(z.string()).optional().describe('Tags for sessions'),
+      },
+    },
+    async ({ label, limit, parallel, template, dryRun, retry, sequential, tags }) => {
+      const args = ['auto'];
+      if (label) args.push('--label', label);
+      if (limit) args.push('--limit', String(limit));
+      if (parallel) args.push('--parallel', String(parallel));
+      if (template) args.push('--template', template);
+      if (dryRun) args.push('--dry-run');
+      if (retry) args.push('--retry', String(retry));
+      if (sequential) args.push('--sequential');
+      if (tags?.length) args.push('--tag', ...tags);
+
+      const proc = spawn('claudetree', args, {
+        cwd,
+        stdio: 'ignore',
+        detached: true,
+      });
+      proc.unref();
+
+      const mode = dryRun ? 'Dry run' : 'Bustercall';
+      return textResult(
+        `${mode} started (PID: ${proc.pid ?? 'unknown'}).\nLabel: ${label ?? 'all'}, Limit: ${limit ?? 10}, Parallel: ${parallel ?? 3}\nUse ct_sessions_list to monitor progress.`,
+      );
+    },
+  );
+
+  // ──────────────────────────────────────
   // ct_stop - Stop a running session
   // ──────────────────────────────────────
   server.registerTool(


### PR DESCRIPTION
## Summary
- **Budget alerts**: Progressive warnings at 50/75/90% of --max-cost
- **MCP ct_bustercall**: 9th MCP tool for AI-driven bustercall orchestration
- Published: @claudetree/cli@0.8.1, @claudetree/mcp@0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)