### PR TITLE
release: v0.11.0 - ct summary, Discord notifications, MCP 11 tools

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @claudetree/cli
 
+## 0.11.0
+
+### Minor Changes
+
+- feat: ct summary, Discord notifications, MCP ct_summary tool
+
+  - New ct summary command with text/markdown/JSON output, time/tag filtering
+  - New DiscordNotifier for webhook notifications (session + batch)
+  - MCP server now has 11 tools including ct_summary
+
+### Patch Changes
+
+- Updated dependencies
+  - @claudetree/core@0.8.0
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Issue-to-PR automation: parallel Claude Code sessions with cost tracking, batch processing & web dashboard",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/summary.test.ts
+++ b/packages/cli/src/commands/summary.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const mockFindAll = vi.fn();
+
+vi.mock('@claudetree/core', () => ({
+  FileSessionRepository: class {
+    findAll = mockFindAll;
+  },
+  FileEventRepository: class {
+    findBySessionId = vi.fn().mockResolvedValue([]);
+  },
+  SessionContextStore: class {
+    findAll = vi.fn().mockResolvedValue([]);
+  },
+}));
+
+import { summaryCommand } from './summary.js';
+
+describe('summaryCommand', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let originalExit: typeof process.exit;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'claudetree-summary-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    originalExit = process.exit;
+    process.exit = vi.fn() as never;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFindAll.mockReset();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exit = originalExit;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    vi.restoreAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should error when not initialized', async () => {
+    (process.exit as unknown as Mock).mockImplementation(() => {
+      throw new Error('exit');
+    });
+    await expect(summaryCommand.parseAsync(['node', 'test'])).rejects.toThrow('exit');
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('not initialized'),
+    );
+  });
+
+  describe('when initialized', () => {
+    beforeEach(async () => {
+      await mkdir(join(testDir, '.claudetree'), { recursive: true });
+    });
+
+    it('should show no sessions message when empty', async () => {
+      mockFindAll.mockResolvedValue([]);
+      (process.exit as unknown as Mock).mockImplementation(() => {
+        throw new Error('exit');
+      });
+      await expect(
+        summaryCommand.parseAsync(['node', 'test']),
+      ).rejects.toThrow('exit');
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No sessions found'),
+      );
+    });
+
+    it('should display summary for sessions', async () => {
+      mockFindAll.mockResolvedValue([
+        {
+          id: 'abc',
+          status: 'completed',
+          issueNumber: 42,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          usage: { inputTokens: 1000, outputTokens: 500, totalCostUsd: 0.05 },
+          tags: ['sprint-1'],
+        },
+      ]);
+
+      await summaryCommand.parseAsync(['node', 'test']);
+
+      const output = consoleLogSpy.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('Summary');
+      expect(output).toContain('#42');
+      expect(output).toContain('0.05');
+    });
+
+    it('should output JSON format', async () => {
+      mockFindAll.mockResolvedValue([
+        {
+          id: 'abc',
+          status: 'completed',
+          issueNumber: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          usage: { inputTokens: 100, outputTokens: 50, totalCostUsd: 0.01 },
+          tags: [],
+        },
+      ]);
+
+      await summaryCommand.parseAsync(['node', 'test', '--format', 'json']);
+
+      const output = consoleLogSpy.mock.calls.map(c => c[0]).join('');
+      const parsed = JSON.parse(output);
+      expect(parsed.total).toBe(1);
+      expect(parsed.completed).toBe(1);
+    });
+
+    it('should have correct command name', () => {
+      expect(summaryCommand.name()).toBe('summary');
+    });
+
+    it('should accept format and since options', () => {
+      expect(summaryCommand.options.find(o => o.long === '--format')).toBeDefined();
+      expect(summaryCommand.options.find(o => o.long === '--since')).toBeDefined();
+    });
+  });
+});

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -1,0 +1,279 @@
+import { Command } from 'commander';
+import { join } from 'node:path';
+import { access, writeFile } from 'node:fs/promises';
+import { FileSessionRepository } from '@claudetree/core';
+import type { Session } from '@claudetree/shared';
+
+const CONFIG_DIR = '.claudetree';
+
+interface SummaryOptions {
+  since?: string;
+  format: string;
+  output?: string;
+  tag?: string[];
+}
+
+function parseRelativeDate(since: string): Date {
+  const now = Date.now();
+  const match = since.match(/^(\d+)([hdwm])$/);
+  if (!match) return new Date(since);
+
+  const val = parseInt(match[1]!, 10);
+  const unit = match[2]!;
+  const msMap: Record<string, number> = {
+    h: 3_600_000,
+    d: 86_400_000,
+    w: 604_800_000,
+    m: 2_592_000_000,
+  };
+  return new Date(now - val * (msMap[unit] ?? 86_400_000));
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  const min = Math.floor(ms / 60_000);
+  if (min < 60) return `${min}m`;
+  const hours = Math.floor(min / 60);
+  return `${hours}h ${min % 60}m`;
+}
+
+function generateTextSummary(
+  sessions: Session[],
+  since: Date,
+): string {
+  const completed = sessions.filter((s) => s.status === 'completed');
+  const failed = sessions.filter((s) => s.status === 'failed');
+  const running = sessions.filter((s) => s.status === 'running');
+
+  let totalCost = 0;
+  let totalInput = 0;
+  let totalOutput = 0;
+
+  for (const s of sessions) {
+    if (s.usage) {
+      totalCost += s.usage.totalCostUsd;
+      totalInput += s.usage.inputTokens;
+      totalOutput += s.usage.outputTokens;
+    }
+  }
+
+  const successRate = sessions.length > 0
+    ? Math.round((completed.length / sessions.length) * 100)
+    : 0;
+
+  const lines: string[] = [
+    '\x1b[36m╔══════════════════════════════════════════╗\x1b[0m',
+    '\x1b[36m║            Session Summary               ║\x1b[0m',
+    '\x1b[36m╚══════════════════════════════════════════╝\x1b[0m',
+    '',
+    `  Period:         Since ${since.toLocaleDateString()}`,
+    `  Total sessions: ${sessions.length}`,
+    `  \x1b[32mCompleted:\x1b[0m      ${completed.length}`,
+    `  \x1b[31mFailed:\x1b[0m         ${failed.length}`,
+    `  \x1b[33mRunning:\x1b[0m        ${running.length}`,
+    `  Success rate:   ${successRate}%`,
+    '',
+    `  \x1b[33mTotal cost:\x1b[0m     $${totalCost.toFixed(4)}`,
+    `  \x1b[33mTotal tokens:\x1b[0m   ${totalInput.toLocaleString()} in / ${totalOutput.toLocaleString()} out`,
+  ];
+
+  if (sessions.length > 0) {
+    const avgCost = totalCost / sessions.length;
+    lines.push(`  Avg cost/session: $${avgCost.toFixed(4)}`);
+  }
+
+  // Issues worked on
+  const issues = sessions
+    .filter((s) => s.issueNumber !== null)
+    .map((s) => `#${s.issueNumber}`);
+  if (issues.length > 0) {
+    lines.push('', `  Issues: ${[...new Set(issues)].join(', ')}`);
+  }
+
+  // Tags breakdown
+  const tagCounts = new Map<string, number>();
+  for (const s of sessions) {
+    for (const tag of s.tags ?? []) {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    }
+  }
+  if (tagCounts.size > 0) {
+    lines.push('', '  Tags:');
+    for (const [tag, count] of tagCounts) {
+      lines.push(`    ${tag}: ${count} session(s)`);
+    }
+  }
+
+  // Completed session details
+  if (completed.length > 0) {
+    lines.push('', '\x1b[32m  Completed Sessions:\x1b[0m');
+    for (const s of completed) {
+      const issue = s.issueNumber ? `#${s.issueNumber}` : s.id.slice(0, 8);
+      const cost = s.usage ? `$${s.usage.totalCostUsd.toFixed(4)}` : '-';
+      const dur = formatDuration(
+        new Date(s.updatedAt).getTime() - new Date(s.createdAt).getTime(),
+      );
+      lines.push(`    ${issue} | ${cost} | ${dur}`);
+    }
+  }
+
+  // Failed session details
+  if (failed.length > 0) {
+    lines.push('', '\x1b[31m  Failed Sessions:\x1b[0m');
+    for (const s of failed) {
+      const issue = s.issueNumber ? `#${s.issueNumber}` : s.id.slice(0, 8);
+      const err = s.lastError
+        ? s.lastError.slice(0, 50)
+        : 'Unknown error';
+      lines.push(`    ${issue} | ${err}`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function generateMarkdownSummary(
+  sessions: Session[],
+  since: Date,
+): string {
+  const completed = sessions.filter((s) => s.status === 'completed');
+  const failed = sessions.filter((s) => s.status === 'failed');
+
+  let totalCost = 0;
+  let totalInput = 0;
+  let totalOutput = 0;
+
+  for (const s of sessions) {
+    if (s.usage) {
+      totalCost += s.usage.totalCostUsd;
+      totalInput += s.usage.inputTokens;
+      totalOutput += s.usage.outputTokens;
+    }
+  }
+
+  const successRate = sessions.length > 0
+    ? Math.round((completed.length / sessions.length) * 100)
+    : 0;
+
+  let md = `# Claude-Tree Session Summary\n\n`;
+  md += `> Period: Since ${since.toLocaleDateString()}\n\n`;
+  md += `| Metric | Value |\n|--------|-------|\n`;
+  md += `| Total sessions | ${sessions.length} |\n`;
+  md += `| Completed | ${completed.length} |\n`;
+  md += `| Failed | ${failed.length} |\n`;
+  md += `| Success rate | ${successRate}% |\n`;
+  md += `| Total cost | $${totalCost.toFixed(4)} |\n`;
+  md += `| Total tokens | ${totalInput.toLocaleString()} in / ${totalOutput.toLocaleString()} out |\n\n`;
+
+  if (completed.length > 0) {
+    md += `## Completed Sessions\n\n`;
+    md += `| Issue | Cost | Duration |\n|-------|------|----------|\n`;
+    for (const s of completed) {
+      const issue = s.issueNumber ? `#${s.issueNumber}` : s.id.slice(0, 8);
+      const cost = s.usage ? `$${s.usage.totalCostUsd.toFixed(4)}` : '-';
+      const dur = formatDuration(
+        new Date(s.updatedAt).getTime() - new Date(s.createdAt).getTime(),
+      );
+      md += `| ${issue} | ${cost} | ${dur} |\n`;
+    }
+    md += '\n';
+  }
+
+  if (failed.length > 0) {
+    md += `## Failed Sessions\n\n`;
+    for (const s of failed) {
+      const issue = s.issueNumber ? `#${s.issueNumber}` : s.id.slice(0, 8);
+      md += `- **${issue}**: ${s.lastError ?? 'Unknown error'}\n`;
+    }
+    md += '\n';
+  }
+
+  md += `---\n*Generated by [claudetree](https://github.com/wonjangcloud9/claude-tree)*\n`;
+  return md;
+}
+
+export const summaryCommand = new Command('summary')
+  .description('Generate a summary of all session activity')
+  .option(
+    '--since <period>',
+    'Time period: 24h, 7d, 30d, or ISO date (default: 24h)',
+    '24h',
+  )
+  .option(
+    '-f, --format <format>',
+    'Output format: text, markdown, json (default: text)',
+    'text',
+  )
+  .option('-o, --output <file>', 'Save to file')
+  .option('--tag <tags...>', 'Filter by tags')
+  .action(async (options: SummaryOptions) => {
+    const cwd = process.cwd();
+    const configDir = join(cwd, CONFIG_DIR);
+
+    try {
+      await access(configDir);
+    } catch {
+      console.error(
+        'Error: claudetree not initialized. Run "claudetree init" first.',
+      );
+      process.exit(1);
+    }
+
+    const sessionRepo = new FileSessionRepository(configDir);
+    let sessions = await sessionRepo.findAll();
+
+    const since = parseRelativeDate(options.since ?? '24h');
+    sessions = sessions.filter(
+      (s) => new Date(s.createdAt).getTime() >= since.getTime(),
+    );
+
+    // Tag filter
+    if (options.tag?.length) {
+      const filterTags = new Set(options.tag);
+      sessions = sessions.filter(
+        (s) => s.tags?.some((t: string) => filterTags.has(t)),
+      );
+    }
+
+    if (sessions.length === 0) {
+      console.log('No sessions found in the specified period.');
+      process.exit(0);
+    }
+
+    let output: string;
+
+    if (options.format === 'json') {
+      output = JSON.stringify(
+        {
+          since: since.toISOString(),
+          total: sessions.length,
+          completed: sessions.filter((s) => s.status === 'completed').length,
+          failed: sessions.filter((s) => s.status === 'failed').length,
+          totalCost: sessions.reduce(
+            (sum, s) => sum + (s.usage?.totalCostUsd ?? 0), 0,
+          ),
+          sessions: sessions.map((s) => ({
+            id: s.id.slice(0, 8),
+            status: s.status,
+            issueNumber: s.issueNumber,
+            cost: s.usage?.totalCostUsd ?? 0,
+            tags: s.tags,
+          })),
+        },
+        null,
+        2,
+      );
+    } else if (options.format === 'markdown') {
+      output = generateMarkdownSummary(sessions, since);
+    } else {
+      output = generateTextSummary(sessions, since);
+    }
+
+    if (options.output) {
+      await writeFile(options.output, output);
+      console.log(`Summary saved to ${options.output}`);
+    } else {
+      console.log(output);
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import { startCommand } from './commands/start.js';
 import { statsCommand } from './commands/stats.js';
 import { statusCommand } from './commands/status.js';
 import { stopCommand } from './commands/stop.js';
+import { summaryCommand } from './commands/summary.js';
 import { watchCommand } from './commands/watch.js';
 import { webCommand } from './commands/web.js';
 
@@ -42,6 +43,7 @@ program.addCommand(chainCommand);
 program.addCommand(configCommand);
 program.addCommand(exportCommand);
 program.addCommand(prCommand);
+program.addCommand(summaryCommand);
 program.addCommand(watchCommand);
 program.addCommand(webCommand);
 program.addCommand(listCommand);

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @claudetree/core
 
+## 0.8.0
+
+### Minor Changes
+
+- feat: ct summary, Discord notifications, MCP ct_summary tool
+
+  - New ct summary command with text/markdown/JSON output, time/tag filtering
+  - New DiscordNotifier for webhook notifications (session + batch)
+  - MCP server now has 11 tools including ct_summary
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Core engine for claudetree: worktree management, GitHub integration, session orchestration & cost tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/infra/discord/DiscordNotifier.test.ts
+++ b/packages/core/src/infra/discord/DiscordNotifier.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordNotifier } from './DiscordNotifier.js';
+
+describe('DiscordNotifier', () => {
+  let notifier: DiscordNotifier;
+
+  beforeEach(() => {
+    notifier = new DiscordNotifier('https://discord.com/api/webhooks/test');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('ok', { status: 200 }),
+    );
+  });
+
+  describe('notify', () => {
+    it('sends POST to webhook URL', async () => {
+      const result = await notifier.notify({ content: 'test' });
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://discord.com/api/webhooks/test',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('returns false on fetch error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await notifier.notify({ content: 'test' });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('notifySession', () => {
+    it('sends session embed for completed session', async () => {
+      await notifier.notifySession({
+        sessionId: 'abc12345',
+        status: 'completed',
+        issueNumber: 42,
+        branch: 'issue-42-fix',
+        duration: 120000,
+        cost: 0.05,
+      });
+
+      const body = JSON.parse(
+        (fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1].body,
+      );
+      expect(body.embeds).toHaveLength(1);
+      expect(body.embeds[0].title).toContain('#42');
+      expect(body.embeds[0].color).toBe(0x36a64f); // green
+    });
+
+    it('sends failed session with error', async () => {
+      await notifier.notifySession({
+        sessionId: 'abc12345',
+        status: 'failed',
+        error: 'Process crashed',
+      });
+
+      const body = JSON.parse(
+        (fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1].body,
+      );
+      expect(body.embeds[0].color).toBe(0xdc3545); // red
+      expect(body.embeds[0].fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Error', value: 'Process crashed' }),
+        ]),
+      );
+    });
+  });
+
+  describe('notifyBatch', () => {
+    it('sends batch summary', async () => {
+      await notifier.notifyBatch([
+        { issue: '#1', status: 'completed' },
+        { issue: '#2', status: 'failed', error: 'timeout' },
+      ]);
+
+      const body = JSON.parse(
+        (fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1].body,
+      );
+      expect(body.embeds[0].title).toContain('Bustercall');
+      expect(body.embeds[0].fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Completed', value: '1' }),
+          expect.objectContaining({ name: 'Failed', value: '1' }),
+        ]),
+      );
+    });
+
+    it('uses green when no failures', async () => {
+      await notifier.notifyBatch([
+        { issue: '#1', status: 'completed' },
+      ]);
+
+      const body = JSON.parse(
+        (fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1].body,
+      );
+      expect(body.embeds[0].color).toBe(0x36a64f);
+    });
+  });
+});

--- a/packages/core/src/infra/discord/DiscordNotifier.ts
+++ b/packages/core/src/infra/discord/DiscordNotifier.ts
@@ -1,0 +1,140 @@
+export interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  color?: number;
+  fields?: Array<{
+    name: string;
+    value: string;
+    inline?: boolean;
+  }>;
+  footer?: { text: string };
+  timestamp?: string;
+}
+
+export interface DiscordMessage {
+  content?: string;
+  embeds?: DiscordEmbed[];
+}
+
+export interface SessionNotification {
+  sessionId: string;
+  status: 'started' | 'completed' | 'failed' | 'paused';
+  issueNumber?: number | null;
+  branch?: string;
+  error?: string;
+  duration?: number;
+  cost?: number;
+}
+
+// Discord color values (decimal)
+const COLORS = {
+  green: 0x36a64f,
+  red: 0xdc3545,
+  yellow: 0xffc107,
+  blue: 0x3498db,
+} as const;
+
+export class DiscordNotifier {
+  constructor(private readonly webhookUrl: string) {}
+
+  async notify(message: DiscordMessage): Promise<boolean> {
+    try {
+      const response = await fetch(this.webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(message),
+      });
+      return response.ok;
+    } catch (err) {
+      console.error('[Discord] Notification failed:', err);
+      return false;
+    }
+  }
+
+  async notifySession(notification: SessionNotification): Promise<boolean> {
+    const embed = this.buildSessionEmbed(notification);
+    return this.notify({ embeds: [embed] });
+  }
+
+  private buildSessionEmbed(notification: SessionNotification): DiscordEmbed {
+    const { sessionId, status, issueNumber, branch, error, duration, cost } = notification;
+
+    const statusEmoji =
+      status === 'started' ? '🚀' :
+      status === 'completed' ? '✅' :
+      status === 'failed' ? '❌' :
+      '⏸️';
+
+    const color =
+      status === 'completed' ? COLORS.green :
+      status === 'failed' ? COLORS.red :
+      status === 'paused' ? COLORS.yellow :
+      COLORS.blue;
+
+    const title = issueNumber
+      ? `${statusEmoji} Issue #${issueNumber}`
+      : `${statusEmoji} Session ${sessionId.slice(0, 8)}`;
+
+    const fields: DiscordEmbed['fields'] = [
+      { name: 'Status', value: status, inline: true },
+    ];
+
+    if (branch) {
+      fields.push({ name: 'Branch', value: `\`${branch}\``, inline: true });
+    }
+
+    if (duration) {
+      const min = Math.floor(duration / 60000);
+      const sec = Math.floor((duration % 60000) / 1000);
+      fields.push({ name: 'Duration', value: `${min}m ${sec}s`, inline: true });
+    }
+
+    if (cost !== undefined) {
+      fields.push({ name: 'Cost', value: `$${cost.toFixed(4)}`, inline: true });
+    }
+
+    if (error) {
+      fields.push({ name: 'Error', value: error.slice(0, 200), inline: false });
+    }
+
+    return {
+      title,
+      color,
+      fields,
+      footer: { text: 'claudetree' },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  async notifyBatch(
+    results: Array<{ issue: string; status: 'completed' | 'failed'; error?: string }>,
+  ): Promise<boolean> {
+    const completed = results.filter((r) => r.status === 'completed').length;
+    const failed = results.filter((r) => r.status === 'failed').length;
+    const color = failed === 0 ? COLORS.green : COLORS.yellow;
+
+    const fields: DiscordEmbed['fields'] = [
+      { name: 'Completed', value: String(completed), inline: true },
+      { name: 'Failed', value: String(failed), inline: true },
+      { name: 'Total', value: String(results.length), inline: true },
+    ];
+
+    if (failed > 0) {
+      const failedText = results
+        .filter((r) => r.status === 'failed')
+        .map((r) => `• ${r.issue}: ${r.error ?? 'Unknown'}`)
+        .join('\n');
+      fields.push({ name: 'Failed Sessions', value: failedText, inline: false });
+    }
+
+    return this.notify({
+      embeds: [{
+        title: `${failed === 0 ? '✅' : '⚠️'} Bustercall Complete`,
+        color,
+        fields,
+        footer: { text: 'claudetree' },
+        timestamp: new Date().toISOString(),
+      }],
+    });
+  }
+}

--- a/packages/core/src/infra/discord/index.ts
+++ b/packages/core/src/infra/discord/index.ts
@@ -1,0 +1,1 @@
+export { DiscordNotifier, type DiscordMessage, type DiscordEmbed } from './DiscordNotifier.js';

--- a/packages/core/src/infra/index.ts
+++ b/packages/core/src/infra/index.ts
@@ -4,6 +4,7 @@ export * from './storage/index.js';
 export * from './websocket/index.js';
 export * from './github/index.js';
 export * from './slack/index.js';
+export * from './discord/index.js';
 export * from './logger/index.js';
 export * from './validation/index.js';
 export * from './ai/index.js';

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @claudetree/mcp
 
+## 0.11.0
+
+### Minor Changes
+
+- feat: ct summary, Discord notifications, MCP ct_summary tool
+
+  - New ct summary command with text/markdown/JSON output, time/tag filtering
+  - New DiscordNotifier for webhook notifications (session + batch)
+  - MCP server now has 11 tools including ct_summary
+
+### Patch Changes
+
+- Updated dependencies
+  - @claudetree/core@0.8.0
+
 ## 0.10.1
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudetree/mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "MCP server for claudetree: expose session management as Model Context Protocol tools",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -66,7 +66,8 @@ describe('MCP Tools', () => {
     expect(tools.has('ct_bustercall')).toBe(true);
     expect(tools.has('ct_pr')).toBe(true);
     expect(tools.has('ct_config')).toBe(true);
-    expect(tools.size).toBe(10);
+    expect(tools.has('ct_summary')).toBe(true);
+    expect(tools.size).toBe(11);
   });
 
   describe('ct_sessions_list', () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -528,4 +528,83 @@ export function registerTools(server: McpServer): void {
       return textResult(lines.join('\n'));
     },
   );
+
+  // ──────────────────────────────────────
+  // ct_summary - Get work activity summary
+  // ──────────────────────────────────────
+  server.registerTool(
+    'ct_summary',
+    {
+      description:
+        'Generate a summary of session activity with success rate, cost analytics, and per-session details',
+      inputSchema: {
+        since: z
+          .string()
+          .optional()
+          .describe('Time period: 24h, 7d, 30d (default: 24h)'),
+        tag: z.string().optional().describe('Filter by tag'),
+      },
+    },
+    async ({ since, tag }) => {
+      const sessionRepo = new FileSessionRepository(join(cwd, CONFIG_DIR));
+      let sessions = await sessionRepo.findAll();
+
+      // Time filter
+      const sinceStr = since ?? '24h';
+      const match = sinceStr.match(/^(\d+)([hdwm])$/);
+      if (match) {
+        const val = parseInt(match[1]!, 10);
+        const unit = match[2]!;
+        const msMap: Record<string, number> = {
+          h: 3_600_000, d: 86_400_000, w: 604_800_000, m: 2_592_000_000,
+        };
+        const cutoff = Date.now() - val * (msMap[unit] ?? 86_400_000);
+        sessions = sessions.filter(
+          (s) => new Date(s.createdAt).getTime() >= cutoff,
+        );
+      }
+
+      if (tag) {
+        sessions = sessions.filter((s) => s.tags?.includes(tag));
+      }
+
+      if (sessions.length === 0) {
+        return textResult('No sessions found in the specified period.');
+      }
+
+      const completed = sessions.filter((s) => s.status === 'completed').length;
+      const failed = sessions.filter((s) => s.status === 'failed').length;
+      const running = sessions.filter((s) => s.status === 'running').length;
+      let totalCost = 0;
+      let totalInput = 0;
+      let totalOutput = 0;
+
+      for (const s of sessions) {
+        if (s.usage) {
+          totalCost += s.usage.totalCostUsd;
+          totalInput += s.usage.inputTokens;
+          totalOutput += s.usage.outputTokens;
+        }
+      }
+
+      const rate = Math.round((completed / sessions.length) * 100);
+
+      const lines = [
+        `Period: ${sinceStr}`,
+        `Sessions: ${sessions.length} (${completed} completed, ${failed} failed, ${running} running)`,
+        `Success rate: ${rate}%`,
+        `Total cost: $${totalCost.toFixed(4)}`,
+        `Tokens: ${totalInput.toLocaleString()} in / ${totalOutput.toLocaleString()} out`,
+      ];
+
+      const issues = [...new Set(
+        sessions.filter((s) => s.issueNumber).map((s) => `#${s.issueNumber}`),
+      )];
+      if (issues.length > 0) {
+        lines.push(`Issues: ${issues.join(', ')}`);
+      }
+
+      return textResult(lines.join('\n'));
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- **ct summary**: Work activity reporting (text/markdown/JSON, time/tag filtering)
- **DiscordNotifier**: Discord webhook notifications for sessions + batches
- **MCP 11 tools**: Added ct_summary tool
- **next-intl**: 4.9.0 → 4.9.1

## Published
- @claudetree/cli@0.11.0
- @claudetree/core@0.8.0
- @claudetree/mcp@0.11.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)